### PR TITLE
[Improve] .gitignore に .claude/ を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Claude Code
+.claude/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## 概要
`.claude/` ディレクトリが Git の追跡対象になっているため、`.gitignore` に追記して除外する。

## 関連イシュー
Closes #35

## 変更内容
- `.gitignore` に `# Claude Code` セクションを追加
- `.claude/` を除外対象として追記

## 備考
`.claude/` は Claude Code のローカル設定・メモリファイルが格納されるディレクトリであり、各開発者の環境固有の情報を含むため共有すべきでない。