### PR TITLE
[Improve] 開発者モードを充実させる

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ function App() {
     shopPurchases,
     buyShopItem,
     cheatBanaCoins,
+    resetUpgrades,
   } = useUpgradeState();
 
   const {
@@ -177,7 +178,7 @@ function App() {
 
   const handleBuyUpgrade = useCallback(
     (upgrade) => {
-      const purchasedSuccess = buyUpgrade(upgrade, score);
+      const purchasedSuccess = buyUpgrade(upgrade, score, devMode);
       if (!purchasedSuccess) return;
       if (!devMode) {
         setScore((currentScore) => currentScore - upgrade.cost);
@@ -477,6 +478,7 @@ function App() {
         purchased={purchased}
         score={score}
         onBuy={handleBuyUpgrade}
+        devMode={devMode}
       />
 
       <BananaWorld
@@ -491,6 +493,7 @@ function App() {
         onCoinCollected={handleCoinCollected}
         shopPurchases={shopPurchases}
         devMode={devMode}
+        onResetUpgrades={resetUpgrades}
       />
     </div>
   );

--- a/src/components/BananaWorld.jsx
+++ b/src/components/BananaWorld.jsx
@@ -42,6 +42,7 @@ const BananaWorld = forwardRef(
       tableWidth = TABLE_WIDTH_RATIO,
       shopPurchases = {},
       devMode = false,
+      onResetUpgrades,
     },
     ref,
   ) => {
@@ -166,6 +167,25 @@ const BananaWorld = forwardRef(
                 {item.label}
               </button>
             ))}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onResetUpgrades?.();
+              }}
+              style={{
+                padding: '6px 14px',
+                background: 'rgba(220,50,50,0.85)',
+                color: '#fff',
+                fontWeight: 800,
+                fontSize: '0.75rem',
+                border: 'none',
+                borderRadius: 20,
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              リセット
+            </button>
           </div>
         )}
 

--- a/src/components/ui/UpgradePanel.jsx
+++ b/src/components/ui/UpgradePanel.jsx
@@ -1,7 +1,7 @@
 import UpgradeGroupCard from './UpgradeGroupCard';
 import { buildGroupUpgradeViewModel } from '../../services/upgradeRules';
 
-function UpgradePanel({ groups, purchased, score, onBuy }) {
+function UpgradePanel({ groups, purchased, score, onBuy, devMode }) {
   return (
     <div
       className="glass-panel"
@@ -25,6 +25,7 @@ function UpgradePanel({ groups, purchased, score, onBuy }) {
             group,
             purchased,
             score,
+            devMode,
           });
 
         return (

--- a/src/hooks/useUpgradeState.js
+++ b/src/hooks/useUpgradeState.js
@@ -44,8 +44,9 @@ export default function useUpgradeState() {
   }, []);
 
   const buyUpgrade = useCallback(
-    (upgrade, score) => {
-      if (!canPurchaseUpgrade({ upgrade, score, purchased })) return false;
+    (upgrade, score, devMode) => {
+      if (!canPurchaseUpgrade({ upgrade, score, purchased, devMode }))
+        return false;
 
       const nextState = applyUpgradeEffects({
         upgrade,
@@ -122,6 +123,14 @@ export default function useUpgradeState() {
     setTreeData((prev) => ({ ...prev, banaCoins: prev.banaCoins + 999 }));
   }, []);
 
+  const resetUpgrades = useCallback(() => {
+    setPurchased(new Set());
+    setBananaPerClick(1);
+    setAutoSpawnRate(0);
+    setGiantChance(0);
+    setUnlockedTiers([BANANA_TIERS[0]]);
+  }, []);
+
   return {
     bananaPerClick,
     autoSpawnRate,
@@ -139,5 +148,6 @@ export default function useUpgradeState() {
     shopPurchases,
     buyShopItem,
     cheatBanaCoins,
+    resetUpgrades,
   };
 }

--- a/src/services/upgradeRules.js
+++ b/src/services/upgradeRules.js
@@ -1,6 +1,7 @@
-export function canPurchaseUpgrade({ upgrade, score, purchased }) {
-  if (score < upgrade.cost) return false;
+export function canPurchaseUpgrade({ upgrade, score, purchased, devMode }) {
   if (purchased.has(upgrade.id)) return false;
+  if (devMode) return true;
+  if (score < upgrade.cost) return false;
   if (upgrade.requires && !purchased.has(upgrade.requires)) return false;
   return true;
 }
@@ -30,7 +31,12 @@ export function applyUpgradeEffects({ upgrade, state, bananaTiers }) {
   return nextState;
 }
 
-export function buildGroupUpgradeViewModel({ group, purchased, score }) {
+export function buildGroupUpgradeViewModel({
+  group,
+  purchased,
+  score,
+  devMode,
+}) {
   const items = group.items;
   const purchasedItems = items.filter((upgrade) => purchased.has(upgrade.id));
 
@@ -39,13 +45,17 @@ export function buildGroupUpgradeViewModel({ group, purchased, score }) {
       ? purchasedItems[purchasedItems.length - 1].label
       : group.defaultLabel;
 
-  const nextItem = items.find(
-    (upgrade) =>
-      !purchased.has(upgrade.id) &&
-      (!upgrade.requires || purchased.has(upgrade.requires)),
-  );
+  const nextItem = devMode
+    ? items.find((upgrade) => !purchased.has(upgrade.id))
+    : items.find(
+        (upgrade) =>
+          !purchased.has(upgrade.id) &&
+          (!upgrade.requires || purchased.has(upgrade.requires)),
+      );
 
-  const affordable = Boolean(nextItem && score >= nextItem.cost);
+  const affordable = devMode
+    ? Boolean(nextItem)
+    : Boolean(nextItem && score >= nextItem.cost);
 
   return {
     currentLabel,


### PR DESCRIPTION
## 概要
開発者モード（Ctrl+Shift+D）において、アップグレードをスコアや前提条件に関係なく購入できるようにする。また、アップグレードを全リセットできるボタンを追加する。

## 関連イシュー
Closes #40
## 変更内容
- `upgradeRules.js`: `canPurchaseUpgrade` に `devMode` フラグを追加。devMode時はスコア不足・前提条件チェックをバイパス（購入済みチェックのみ残す）
- `upgradeRules.js`: `buildGroupUpgradeViewModel` も同様に修正。devMode時は前提条件なしで次のアイテムを表示し、常に購入可能として表示
- `useUpgradeState.js`: `buyUpgrade` に `devMode` パラメータを追加し、`canPurchaseUpgrade` へ渡すよう修正
- `useUpgradeState.js`: `resetUpgrades` 関数を追加。購入済みアップグレードと各パラメータを初期状態に戻す
- `BananaWorld.jsx`: devMode時の操作ボタン群に「リセット」ボタンを追加
- `App.jsx` / `UpgradePanel.jsx`: `devMode` と `onResetUpgrades` を各コンポーネントへ受け渡し

## 備考
リセットはアップグレードのみ対象（スコア・バナナコイン・ツリーはリセットしない）