### PR TITLE
Fix special banana not showing in UnlockedBananaTiers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -301,6 +301,8 @@ function App() {
         magicBananaCount={shopPurchases['banana_magic'] ?? 0}
         isAllGiant={isAllGiant}
         blackholeBananaCount={shopPurchases['banana_blackhole'] ?? 0}
+        onekindBananaCount={shopPurchases['banana_onekind'] ?? 0}
+        isOneKind={isOneKind}
       />
       <ShopButton banaCoins={banaCoins} onOpen={() => setIsShopOpen(true)} />
       {isShopOpen && (

--- a/src/components/ui/UnlockedBananaTiers.jsx
+++ b/src/components/ui/UnlockedBananaTiers.jsx
@@ -21,9 +21,14 @@ function UnlockedBananaTiers({
   magicBananaCount,
   isAllGiant,
   blackholeBananaCount,
+  onekindBananaCount,
+  isOneKind,
 }) {
   const hasSpecial =
-    nuiBananaCount > 0 || magicBananaCount > 0 || blackholeBananaCount > 0;
+    nuiBananaCount > 0 ||
+    magicBananaCount > 0 ||
+    blackholeBananaCount > 0 ||
+    onekindBananaCount > 0;
 
   return (
     <div
@@ -170,6 +175,48 @@ function UnlockedBananaTiers({
                 }}
               >
                 ×{blackholeBananaCount}
+              </span>
+            </div>
+          )}
+          {onekindBananaCount > 0 && (
+            <div
+              className="glass-panel"
+              style={{
+                padding: '6px 14px',
+                fontSize: '0.75rem',
+                fontWeight: 800,
+                color: '#e11d48',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                userSelect: 'none',
+                transition: 'all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+                borderLeft: '3px solid #e11d48',
+                background: isOneKind
+                  ? 'rgba(225, 29, 72, 0.15)'
+                  : 'rgba(255, 255, 255, 0.8)',
+                boxShadow: isOneKind
+                  ? '0 2px 12px rgba(225, 29, 72, 0.3)'
+                  : '0 2px 10px rgba(0,0,0,0.05)',
+              }}
+            >
+              <img
+                src={`${import.meta.env.BASE_URL}banana_onekind.png`}
+                alt="oneバナナ"
+                style={{ width: 24, height: 24, objectFit: 'contain' }}
+              />
+              <span>oneバナナ</span>
+              <span
+                style={{
+                  fontSize: '0.65rem',
+                  fontWeight: 700,
+                  color: '#e11d48',
+                  marginLeft: 'auto',
+                  paddingLeft: 8,
+                  opacity: 0.8,
+                }}
+              >
+                ×{onekindBananaCount}
               </span>
             </div>
           )}


### PR DESCRIPTION
## 概要
特殊バナナ（oneバナナ）を購入してもUnlockedBananaTiersのSpecialセクションに表示されないバグを修正。

## 関連イシュー
Closes #53

## 変更内容
- `App.jsx`: `onekindBananaCount` と `isOneKind` プロパティを `UnlockedBananaTiers` に渡すよう追加
- `UnlockedBananaTiers.jsx`: oneバナナの表示ブロックを追加（他の特殊バナナと同じパターン）
  - `hasSpecial` 判定に `onekindBananaCount` を追加
  - oneKind効果発動中は背景がハイライトされる

## 備考
- 他の3種（ぬい・マジック・ブラックホール）は既に実装済みで、oneバナナのみ抜けていた