### PR TITLE
feat: add coin spawn flash on tree level-up and fix devMode water

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
 import FeverBurst from './components/ui/FeverBurst';
 import SpawnFlash from './components/ui/SpawnFlash';
+import CoinSpawnFlash from './components/ui/CoinSpawnFlash';
 import FloatingScoreText from './components/ui/FloatingScoreText';
 import ScoreDisplay from './components/ui/ScoreDisplay';
 import BananaTree from './components/ui/BananaTree';
@@ -67,6 +68,7 @@ function App() {
   const [clickEffects, setClickEffects] = useState([]);
   const [feverBursts, setFeverBursts] = useState([]);
   const [spawnFlashes, setSpawnFlashes] = useState([]);
+  const [coinFlashes, setCoinFlashes] = useState([]);
   const [scoreBump, setScoreBump] = useState(false);
   const [perSecond, setPerSecond] = useState(0);
   const [devMode, setDevMode] = useState(false);
@@ -94,6 +96,13 @@ function App() {
     if (treeLevel > prevTreeLevelRef.current) {
       const x = 80 + Math.random() * (window.innerWidth - 160);
       bananaWorldRef.current?.spawnCoin(x);
+
+      const id = ++_textId;
+      setCoinFlashes((prev) => [...prev, { id, x }]);
+      setTimeout(
+        () => setCoinFlashes((prev) => prev.filter((f) => f.id !== id)),
+        1800,
+      );
     }
     prevTreeLevelRef.current = treeLevel;
   }, [treeLevel]);
@@ -214,8 +223,8 @@ function App() {
   }, []);
 
   const handleWaterTree = useCallback(() => {
-    const cost = waterTree(score);
-    if (cost && !devMode) {
+    const cost = waterTree(score, devMode);
+    if (cost !== false && !devMode) {
       setScore((currentScore) => currentScore - cost);
     }
   }, [waterTree, score, devMode]);
@@ -580,6 +589,10 @@ function App() {
 
       {spawnFlashes.map((flash) => (
         <SpawnFlash key={flash.id} flash={flash} />
+      ))}
+
+      {coinFlashes.map((flash) => (
+        <CoinSpawnFlash key={flash.id} flash={flash} />
       ))}
 
       <UpgradePanel

--- a/src/components/ui/BananaTree.jsx
+++ b/src/components/ui/BananaTree.jsx
@@ -211,7 +211,7 @@ export default function BananaTree({
                 height: 22,
                 objectFit: 'contain',
                 flexShrink: 0,
-                animation: 'coinGlow 2s ease-in-out infinite',
+                animation: 'treeCoinGlow 2s ease-in-out infinite',
                 opacity: progress >= 95 ? 1 : 0.45,
                 transition: 'opacity 0.5s',
               }}

--- a/src/components/ui/CoinSpawnFlash.jsx
+++ b/src/components/ui/CoinSpawnFlash.jsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+
+function CoinSpawnFlash({ flash }) {
+  // シュワっと弾ける小さな黄金の星屑（放射状に広がる）
+  const [particles] = useState(() =>
+    Array.from({ length: 12 }).map((_, i) => {
+      const angle = (i * 360) / 12 + (Math.random() * 20 - 10);
+      const dist = 60 + Math.random() * 50;
+      return {
+        id: i,
+        tx: Math.cos((angle * Math.PI) / 180) * dist,
+        ty: Math.sin((angle * Math.PI) / 180) * dist,
+        size: 5 + Math.random() * 4,
+        delay: Math.random() * 0.2,
+      };
+    }),
+  );
+
+  return (
+    <>
+      {/* ぽわっと広がるメインの輝き */}
+      <div
+        style={{
+          position: 'fixed',
+          left: flash.x,
+          top: 0, // スポーン位置 (上部)
+          width: 180,
+          height: 180,
+          borderRadius: '50%',
+          background:
+            'radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(135, 140, 150, 0.7) 40%, transparent 70%)',
+          pointerEvents: 'none',
+          zIndex: 19,
+          transform: 'translate(-50%, -50%)',
+          animation:
+            'coinPopGlow 1.2s cubic-bezier(0.18, 0.89, 0.32, 1.28) forwards',
+        }}
+      />
+
+      {/* キラッと光って回る四芒星または十字のスパークル */}
+      <div
+        style={{
+          position: 'fixed',
+          left: flash.x,
+          top: 0,
+          width: 140,
+          height: 140,
+          background:
+            'conic-gradient(from 0deg at 50% 50%, transparent 0deg, rgba(255, 255, 255, 1) 4deg, transparent 8deg, transparent 82deg, rgba(255, 255, 255, 1) 86deg, transparent 90deg, transparent 172deg, rgba(255, 255, 255, 1) 176deg, transparent 180deg, transparent 262deg, rgba(255, 255, 255, 1) 266deg, transparent 270deg, transparent 360deg)',
+          pointerEvents: 'none',
+          zIndex: 22,
+          transform: 'translate(-50%, -50%)',
+          animation:
+            'coinSparkleSpin 1.4s cubic-bezier(0.25, 0.1, 0.25, 1) forwards',
+        }}
+      />
+
+      {/* サッと広がる小さなリング */}
+      <div
+        style={{
+          position: 'fixed',
+          left: flash.x,
+          top: 0,
+          width: 70,
+          height: 70,
+          borderRadius: '50%',
+          border: '3px solid rgba(170, 175, 185, 0.8)',
+          pointerEvents: 'none',
+          zIndex: 20,
+          transform: 'translate(-50%, -50%)',
+          animation: 'coinRingExpand 1.0s ease-out forwards',
+        }}
+      />
+
+      {/* プチプチ弾ける小さな光の粉 */}
+      {particles.map((p) => (
+        <div
+          key={p.id}
+          style={{
+            position: 'fixed',
+            left: flash.x,
+            top: 0,
+            width: p.size,
+            height: p.size,
+            borderRadius: '50%',
+            background: `rgba(255, 255, 255, 1)`,
+            boxShadow: `0 0 ${p.size}px rgba(110, 115, 125, 0.9)`,
+            pointerEvents: 'none',
+            zIndex: 23,
+            '--tx': `${p.tx}px`,
+            '--ty': `${p.ty}px`,
+            animation: `coinMiniBurst 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) ${p.delay}s forwards`,
+            opacity: 0,
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+export default CoinSpawnFlash;

--- a/src/components/ui/FeverBurst.jsx
+++ b/src/components/ui/FeverBurst.jsx
@@ -72,21 +72,56 @@ function FeverBurst({ burst }) {
         }}
       />
 
+      {/* 着弾時のエレガントな横閃光 */}
+      <div
+        style={{
+          position: 'fixed',
+          left: burst.x,
+          top: burst.y,
+          width: 600,
+          height: 12,
+          background: `radial-gradient(ellipse at center, rgba(255,255,255,1) 0%, rgba(${light},0.8) 20%, transparent 70%)`,
+          pointerEvents: 'none',
+          zIndex: 23,
+          transform: 'translate(-50%, -50%)',
+          animation:
+            'elegantFlareHorizontal 0.8s cubic-bezier(0.25, 0.1, 0.25, 1) forwards',
+        }}
+      />
+
       {/* 中心から滲むより鮮やかで強い光 */}
       <div
         style={{
           position: 'fixed',
           left: burst.x,
           top: burst.y,
-          width: 120, // 大幅に拡大
-          height: 120,
+          width: 160, // さらに拡大
+          height: 160,
           borderRadius: '50%',
-          background: `radial-gradient(circle, rgba(${core},1) 0%, rgba(${main},0.8) 20%, rgba(${light},0.4) 50%, transparent 80%)`,
+          background: `radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(${light},0.9) 20%, rgba(${core},0.7) 40%, rgba(${main},0.3) 70%, transparent 80%)`,
           transform: 'translate(-50%, -50%)',
           pointerEvents: 'none',
           zIndex: 22,
           animation:
             'elegantCore 0.8s cubic-bezier(0.25, 0.1, 0.25, 1) forwards',
+        }}
+      />
+
+      {/* 中心の強烈な白い芯 */}
+      <div
+        style={{
+          position: 'fixed',
+          left: burst.x,
+          top: burst.y,
+          width: 60,
+          height: 60,
+          borderRadius: '50%',
+          background: `radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(255,255,255,0.6) 40%, transparent 80%)`,
+          transform: 'translate(-50%, -50%)',
+          pointerEvents: 'none',
+          zIndex: 24,
+          animation:
+            'elegantCore 0.6s cubic-bezier(0.25, 0.1, 0.25, 1) forwards',
         }}
       />
 

--- a/src/hooks/useUpgradeState.js
+++ b/src/hooks/useUpgradeState.js
@@ -80,10 +80,10 @@ export default function useUpgradeState() {
   );
 
   const waterTree = useCallback(
-    (currentScore) => {
+    (currentScore, devMode = false) => {
       const cost = getWaterCost(treeData.waterCount);
 
-      if (currentScore < cost) return false;
+      if (!devMode && currentScore < cost) return false;
 
       setTreeData((prev) => {
         const maxGrowth = getMaxGrowth(prev.level);

--- a/src/index.css
+++ b/src/index.css
@@ -599,6 +599,85 @@ body {
   }
 }
 
+@keyframes treeCoinGlow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 2px rgba(212, 175, 55, 0.4));
+    transform: scale(0.9);
+  }
+
+  50% {
+    filter: drop-shadow(0 0 12px rgba(212, 175, 55, 1));
+    transform: scale(1.15);
+  }
+}
+
+@keyframes coinPopGlow {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+
+  20% {
+    transform: translate(-50%, -50%) scale(1.2);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(1.4);
+    opacity: 0;
+  }
+}
+
+@keyframes coinSparkleSpin {
+  0% {
+    transform: translate(-50%, -50%) scale(0) rotate(0deg);
+    opacity: 0;
+  }
+
+  30% {
+    transform: translate(-50%, -50%) scale(1) rotate(90deg);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(0) rotate(180deg);
+    opacity: 0;
+  }
+}
+
+@keyframes coinRingExpand {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 1;
+    border-width: 4px;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(3);
+    opacity: 0;
+    border-width: 1px;
+  }
+}
+
+@keyframes coinMiniBurst {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+
+  20% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty)))
+      scale(0.3);
+    opacity: 0;
+  }
+}
+
 /* Custom Scrollbar for premium feel */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## 概要

ツリーレベルアップ時のコインフラッシュエフェクトを追加し、devMode でのコスト制限バグを修正する。

## 関連イシュー

なし（#62 マージ後の追加改善）

## 変更内容

- `CoinSpawnFlash.jsx` 新規追加
  - ツリーレベルアップ時にコインが弾けるフラッシュエフェクトを表示
  - ポップグロー・スパークルスピン・リング拡散・ミニバーストのアニメーション構成
- `App.jsx`
  - `CoinSpawnFlash` を組み込み、ツリーレベルアップ検出時に発火
  - `waterTree` に `devMode` を渡すよう修正（コスト制限バイパス）
- `FeverBurst.jsx`
  - 横閃光（600px）を追加
  - 中心コアを拡大（120px → 160px）し白い芯（60px）を追加
- `BananaTree.jsx`
  - アニメーション名を `coinGlow` → `treeCoinGlow` にリネーム（名前衝突を回避）
- `useUpgradeState.js`
  - `waterTree` が devMode 時にもスコア不足でブロックされるバグを修正
- `index.css`
  - `treeCoinGlow`, `coinPopGlow`, `coinSparkleSpin`, `coinRingExpand`, `coinMiniBurst` を追加

## 備考

`coinGlow` → `treeCoinGlow` のリネームは `CoinSpawnFlash` 内のアニメーション名との衝突を防ぐための変更。