### PR TITLE
スキル選択UIをツリーパネル右横に分離しアップグレードバーとの重なりを解消

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -474,7 +474,7 @@ function App() {
               padding: '4px 14px',
               fontSize: '0.7rem',
               fontWeight: 800,
-              color: '#9333ea',
+              color: 'var(--special-magic)',
               whiteSpace: 'nowrap',
               letterSpacing: '0.04em',
             }}
@@ -587,7 +587,7 @@ function App() {
             fontSize: '1.6rem',
             fontWeight: 900,
             fontFamily: '"Outfit", sans-serif',
-            color: '#d4af37',
+            color: 'var(--accent-gold)',
             pointerEvents: 'none',
             animation:
               'floatUpFade 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards',

--- a/src/components/ui/BananaTree.jsx
+++ b/src/components/ui/BananaTree.jsx
@@ -3,13 +3,13 @@ import { Droplets } from 'lucide-react';
 import { getMaxGrowth, getWaterCost } from '../../hooks/useUpgradeState';
 
 const TREE_STAGES = [
-  { label: '種子', color: '#8bc34a' },
-  { label: '芽吹き', color: '#7cb342' },
-  { label: '若苗', color: '#558b2f' },
-  { label: '若葉', color: '#4caf50' },
-  { label: '成長期', color: '#388e3c' },
-  { label: '開花', color: '#a5d240' },
-  { label: '成熟', color: '#d4af37' },
+  { label: '種子', color: 'var(--tree-green-1)' },
+  { label: '芽吹き', color: 'var(--tree-green-2)' },
+  { label: '若苗', color: 'var(--tree-green-3)' },
+  { label: '若葉', color: 'var(--tree-green-4)' },
+  { label: '成長期', color: 'var(--tree-green-5)' },
+  { label: '開花', color: 'var(--tree-green-6)' },
+  { label: '成熟', color: 'var(--accent-gold)' },
 ];
 
 // スキル種別ごとのカラーテーマ
@@ -129,15 +129,23 @@ export default function BananaTree({
   }, [treeLevel]);
 
   return (
-    <>
+    <div
+      style={{
+        position: 'fixed',
+        top: 130,
+        left: 24,
+        zIndex: 10,
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: 8,
+        pointerEvents: 'none',
+      }}
+    >
       {/* ── メインパネル ── */}
       <div
         className="glass-panel"
         style={{
-          position: 'fixed',
-          top: 130,
-          left: 24,
-          zIndex: 10,
           padding: '14px 16px',
           display: 'flex',
           flexDirection: 'column',
@@ -150,6 +158,7 @@ export default function BananaTree({
             ? '1px solid var(--accent-gold-soft)'
             : '1px solid var(--glass-border)',
           animation: showLevelUp ? 'levelUpFlash 0.8s ease-out' : undefined,
+          pointerEvents: 'auto',
         }}
       >
         {/* Top: tree image + level badge */}
@@ -194,7 +203,7 @@ export default function BananaTree({
                 color: currentStage.color,
                 background: isGold
                   ? 'rgba(212,175,55,0.14)'
-                  : 'rgba(76,175,80,0.1)',
+                  : 'var(--status-maxed-bg)',
                 padding: '1px 8px',
                 borderRadius: 10,
                 letterSpacing: '0.05em',
@@ -237,7 +246,7 @@ export default function BananaTree({
                 style={{
                   flex: 1,
                   height: 7,
-                  background: 'rgba(0,0,0,0.07)',
+                  background: 'var(--progress-bg)',
                   borderRadius: 4,
                   overflow: 'hidden',
                 }}
@@ -292,14 +301,14 @@ export default function BananaTree({
                 width: '100%',
                 justifyContent: 'center',
                 background: canAfford
-                  ? 'linear-gradient(135deg, #64B5F6 0%, #1E88E5 100%)'
-                  : '#ececec',
-                color: canAfford ? '#fff' : '#bbb',
+                  ? 'linear-gradient(135deg, var(--accent-gold-soft) 0%, var(--accent-gold) 100%)'
+                  : 'var(--disabled-bg)',
+                color: canAfford ? '#fff' : 'var(--disabled-text)',
                 fontSize: '0.7rem',
                 fontWeight: 800,
                 cursor: canAfford ? 'pointer' : 'not-allowed',
                 boxShadow: canAfford
-                  ? '0 3px 10px rgba(30,136,229,0.3)'
+                  ? '0 3px 10px var(--accent-gold-glow)'
                   : 'none',
                 transition: 'all 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
               }}
@@ -307,13 +316,13 @@ export default function BananaTree({
                 if (canAfford) {
                   e.currentTarget.style.transform = 'scale(1.05)';
                   e.currentTarget.style.boxShadow =
-                    '0 5px 14px rgba(30,136,229,0.4)';
+                    '0 5px 14px rgba(212,175,55,0.4)';
                 }
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = 'scale(1)';
                 e.currentTarget.style.boxShadow = canAfford
-                  ? '0 3px 10px rgba(30,136,229,0.3)'
+                  ? '0 3px 10px rgba(212,175,55,0.25)'
                   : 'none';
               }}
               onMouseDown={(e) => {
@@ -372,7 +381,7 @@ export default function BananaTree({
                 const dotColor = isDone
                   ? getSkillTheme(chosenSkills[i]).dot
                   : isPending
-                    ? '#ff9800'
+                    ? 'var(--pending-orange)'
                     : 'rgba(0,0,0,0.1)';
                 return (
                   <div
@@ -454,138 +463,7 @@ export default function BananaTree({
               </div>
             )}
 
-            {/* ── スキル選択中（モダンデザイン） ── */}
-            {pendingChoice && (
-              <div
-                style={{
-                  width: '100%',
-                  marginTop: 6,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  borderRadius: 12,
-                  background: 'rgba(255, 255, 255, 0.4)',
-                  border: '1px solid rgba(0,0,0,0.05)',
-                  overflow: 'hidden',
-                  boxShadow: '0 2px 10px rgba(0,0,0,0.02)',
-                }}
-              >
-                {/* ヘッダー部分 */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: 6,
-                    padding: '5px 0',
-                    background:
-                      'linear-gradient(135deg, rgba(255,152,0,0.1) 0%, rgba(255,183,77,0.15) 100%)',
-                    borderBottom: '1px solid rgba(255,152,0,0.15)',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: 4,
-                      height: 4,
-                      borderRadius: '50%',
-                      background: '#ffb74d',
-                    }}
-                  />
-                  <span
-                    style={{
-                      fontSize: '0.6rem',
-                      fontWeight: 800,
-                      color: '#f57c00',
-                      letterSpacing: '0.06em',
-                    }}
-                  >
-                    SKILL UNLOCKED
-                  </span>
-                  <div
-                    style={{
-                      width: 4,
-                      height: 4,
-                      borderRadius: '50%',
-                      background: '#ffb74d',
-                    }}
-                  />
-                </div>
-
-                {/* リスト部分 */}
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  {pendingChoice.map((skill, idx) => {
-                    const theme = getSkillTheme(skill);
-                    const isLast = idx === pendingChoice.length - 1;
-                    return (
-                      <button
-                        key={skill.id}
-                        onClick={() => onChooseSkill(skill)}
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 8,
-                          padding: '10px 10px',
-                          border: 'none',
-                          borderBottom: isLast
-                            ? 'none'
-                            : '1px solid rgba(0,0,0,0.04)',
-                          background: 'transparent',
-                          cursor: 'pointer',
-                          transition: 'all 0.2s ease',
-                          textAlign: 'left',
-                        }}
-                        onMouseEnter={(e) => {
-                          e.currentTarget.style.background = theme.bg;
-                          e.currentTarget.style.paddingLeft = '14px';
-                        }}
-                        onMouseLeave={(e) => {
-                          e.currentTarget.style.background = 'transparent';
-                          e.currentTarget.style.paddingLeft = '10px';
-                        }}
-                      >
-                        <div
-                          style={{
-                            fontSize: '1.2rem',
-                            filter: `drop-shadow(0 2px 4px ${theme.glow})`,
-                            flexShrink: 0,
-                          }}
-                        >
-                          {skill.icon}
-                        </div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 2,
-                          }}
-                        >
-                          <span
-                            style={{
-                              fontSize: '0.65rem',
-                              fontWeight: 800,
-                              color: theme.text,
-                              lineHeight: 1.1,
-                            }}
-                          >
-                            {skill.name}
-                          </span>
-                          <span
-                            style={{
-                              fontSize: '0.5rem',
-                              fontWeight: 600,
-                              color: 'var(--text-muted)',
-                              lineHeight: 1.25,
-                              opacity: 0.8,
-                            }}
-                          >
-                            {skill.description.replace(/\n/g, ' ')}
-                          </span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
+            {/* スキル選択中の場合はパネル外にフローティング表示 */}
 
             {/* ── スキル未解放ヒント ── */}
             {!pendingChoice && chosenSkills.length === 0 && (
@@ -604,6 +482,144 @@ export default function BananaTree({
           </div>
         </div>
       </div>
-    </>
+
+      {/* ── スキル選択パネル（ツリーパネルの直下） ── */}
+      {pendingChoice && (
+        <div
+          className="glass-panel"
+          style={{
+            width: 192,
+            display: 'flex',
+            flexDirection: 'column',
+            borderRadius: 16,
+            overflow: 'hidden',
+            border: '1px solid rgba(255,152,0,0.25)',
+            boxShadow:
+              '0 8px 32px rgba(255,152,0,0.12), 0 2px 10px rgba(0,0,0,0.06)',
+            animation: 'slideInRight 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+            userSelect: 'none',
+            pointerEvents: 'auto',
+          }}
+        >
+          {/* ヘッダー部分 */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              padding: '7px 0',
+              background:
+                'linear-gradient(135deg, rgba(255,152,0,0.1) 0%, rgba(255,183,77,0.15) 100%)',
+              borderBottom: '1px solid rgba(255,152,0,0.15)',
+            }}
+          >
+            <div
+              style={{
+                width: 4,
+                height: 4,
+                borderRadius: '50%',
+                background: 'var(--pending-orange-light)',
+              }}
+            />
+            <span
+              style={{
+                fontSize: '0.6rem',
+                fontWeight: 800,
+                color: 'var(--pending-orange-dark)',
+                letterSpacing: '0.06em',
+              }}
+            >
+              SKILL UNLOCKED
+            </span>
+            <div
+              style={{
+                width: 4,
+                height: 4,
+                borderRadius: '50%',
+                background: 'var(--pending-orange-light)',
+              }}
+            />
+          </div>
+
+          {/* リスト部分 */}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {pendingChoice.map((skill, idx) => {
+              const theme = getSkillTheme(skill);
+              const isLast = idx === pendingChoice.length - 1;
+              return (
+                <button
+                  key={skill.id}
+                  onClick={() => onChooseSkill(skill)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '10px 12px',
+                    border: 'none',
+                    borderBottom: isLast
+                      ? 'none'
+                      : '1px solid rgba(0,0,0,0.04)',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    textAlign: 'left',
+                    animation: `slideInRight 0.3s ease both`,
+                    animationDelay: `${idx * 0.06}s`,
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = theme.bg;
+                    e.currentTarget.style.paddingLeft = '16px';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'transparent';
+                    e.currentTarget.style.paddingLeft = '12px';
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '1.2rem',
+                      filter: `drop-shadow(0 2px 4px ${theme.glow})`,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {skill.icon}
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 2,
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: '0.65rem',
+                        fontWeight: 800,
+                        color: theme.text,
+                        lineHeight: 1.1,
+                      }}
+                    >
+                      {skill.name}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: '0.5rem',
+                        fontWeight: 600,
+                        color: 'var(--text-muted)',
+                        lineHeight: 1.25,
+                        opacity: 0.8,
+                      }}
+                    >
+                      {skill.description.replace(/\n/g, ' ')}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/ui/ClickRipple.jsx
+++ b/src/components/ui/ClickRipple.jsx
@@ -8,7 +8,7 @@ function ClickRipple({ effect }) {
         width: 50,
         height: 50,
         borderRadius: '50%',
-        border: '3px solid rgba(255, 200, 0, 0.9)',
+        border: '3px solid var(--ripple-color)',
         pointerEvents: 'none',
         zIndex: 20,
         animation: 'ripple 0.6s ease-out forwards',

--- a/src/components/ui/ScoreDisplay.jsx
+++ b/src/components/ui/ScoreDisplay.jsx
@@ -22,7 +22,9 @@ function ScoreDisplay({ score, perSecond, scoreBump, devMode }) {
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ fontSize: '1.2rem', color: '#d4af37' }}>🍌</span>
+        <span style={{ fontSize: '1.2rem', color: 'var(--accent-gold)' }}>
+          🍌
+        </span>
         <span
           style={{
             fontSize: '1.4rem',

--- a/src/components/ui/ShopModal.jsx
+++ b/src/components/ui/ShopModal.jsx
@@ -106,7 +106,7 @@ export default function ShopModal({
           style={{
             borderRadius: '18px',
             background: 'linear-gradient(135deg, #f6fef0, #fffde7)',
-            border: '1px solid rgba(139,195,74,0.25)',
+            border: '1px solid var(--status-maxed-border)',
             padding: '14px 16px',
             display: 'flex',
             alignItems: 'center',
@@ -151,8 +151,8 @@ export default function ShopModal({
                 style={{
                   fontSize: '0.68rem',
                   fontWeight: 700,
-                  color: '#8bc34a',
-                  background: 'rgba(139,195,74,0.12)',
+                  color: 'var(--status-maxed-light)',
+                  background: 'var(--status-maxed-bg)',
                   padding: '1px 8px',
                   borderRadius: 8,
                 }}
@@ -178,7 +178,7 @@ export default function ShopModal({
               <div
                 style={{
                   height: 5,
-                  background: 'rgba(0,0,0,0.07)',
+                  background: 'var(--progress-bg)',
                   borderRadius: 3,
                   overflow: 'hidden',
                 }}
@@ -187,7 +187,8 @@ export default function ShopModal({
                   style={{
                     height: '100%',
                     width: `${progress}%`,
-                    background: 'linear-gradient(90deg, #8bc34a, #c6e05a)',
+                    background:
+                      'linear-gradient(90deg, var(--status-maxed-light), #c6e05a)',
                     borderRadius: 3,
                     transition: 'width 0.8s cubic-bezier(0.4, 0, 0.2, 1)',
                   }}
@@ -263,7 +264,7 @@ export default function ShopModal({
                   background: isMaxed
                     ? 'linear-gradient(135deg, #f0fae8, #e8f5e0)'
                     : 'linear-gradient(135deg, #fffef5, #fffbe8)',
-                  border: `1.5px solid ${isMaxed ? 'rgba(76,175,80,0.25)' : 'var(--accent-gold-soft)'}`,
+                  border: `1.5px solid ${isMaxed ? 'var(--status-maxed-border)' : 'var(--accent-gold-soft)'}`,
                 }}
               >
                 {/* Item image */}
@@ -306,8 +307,8 @@ export default function ShopModal({
                         style={{
                           fontSize: '0.6rem',
                           fontWeight: 800,
-                          color: '#4caf50',
-                          background: 'rgba(76,175,80,0.1)',
+                          color: 'var(--status-maxed)',
+                          background: 'var(--status-maxed-bg)',
                           padding: '1px 7px',
                           borderRadius: 8,
                           letterSpacing: '0.04em',
@@ -336,7 +337,7 @@ export default function ShopModal({
                       style={{
                         fontSize: '0.68rem',
                         fontWeight: 700,
-                        color: '#1e3a5f',
+                        color: 'var(--effect-spawn-chance)',
                         marginBottom: 8,
                         display: 'flex',
                         alignItems: 'center',
@@ -364,7 +365,12 @@ export default function ShopModal({
                             %
                           </span>
                           {!isMaxed && (
-                            <span style={{ color: '#3b82f6', fontWeight: 600 }}>
+                            <span
+                              style={{
+                                color: 'var(--effect-spawn-chance-next)',
+                                fontWeight: 600,
+                              }}
+                            >
                               → 次購入で{' '}
                               {(
                                 item.spawnChancePerBanana *
@@ -385,7 +391,7 @@ export default function ShopModal({
                       style={{
                         fontSize: '0.68rem',
                         fontWeight: 700,
-                        color: '#0369a1',
+                        color: 'var(--effect-onekind)',
                         marginBottom: 8,
                         display: 'flex',
                         alignItems: 'center',
@@ -409,7 +415,12 @@ export default function ShopModal({
                             効果
                           </span>
                           {!isMaxed && (
-                            <span style={{ color: '#0284c7', fontWeight: 600 }}>
+                            <span
+                              style={{
+                                color: 'var(--effect-onekind-next)',
+                                fontWeight: 600,
+                              }}
+                            >
                               → 次購入で{' '}
                               {getEffectDuration(item.effect, count + 1)}s
                             </span>
@@ -425,7 +436,7 @@ export default function ShopModal({
                       style={{
                         fontSize: '0.68rem',
                         fontWeight: 700,
-                        color: '#9333ea',
+                        color: 'var(--special-magic)',
                         marginBottom: 8,
                         display: 'flex',
                         alignItems: 'center',
@@ -449,7 +460,12 @@ export default function ShopModal({
                             効果
                           </span>
                           {!isMaxed && (
-                            <span style={{ color: '#a855f7', fontWeight: 600 }}>
+                            <span
+                              style={{
+                                color: 'var(--special-magic-light)',
+                                fontWeight: 600,
+                              }}
+                            >
                               → 次購入で{' '}
                               {getEffectDuration(item.effect, count + 1)}s
                             </span>
@@ -465,7 +481,7 @@ export default function ShopModal({
                       style={{
                         fontSize: '0.68rem',
                         fontWeight: 700,
-                        color: '#ff8c00',
+                        color: 'var(--special-nui)',
                         marginBottom: 8,
                         display: 'flex',
                         alignItems: 'center',

--- a/src/components/ui/UnlockedBananaTiers.jsx
+++ b/src/components/ui/UnlockedBananaTiers.jsx
@@ -63,15 +63,15 @@ function UnlockedBananaTiers({
                 padding: '6px 14px',
                 fontSize: '0.75rem',
                 fontWeight: 800,
-                color: '#ff8c00',
+                color: 'var(--special-nui)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: 8,
                 userSelect: 'none',
                 transition: 'all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                borderLeft: '3px solid #ff8c00',
+                borderLeft: '3px solid var(--special-nui)',
                 background: isFever
-                  ? 'rgba(255, 140, 0, 0.15)'
+                  ? 'var(--special-nui-light)'
                   : 'rgba(255, 255, 255, 0.8)',
                 boxShadow: isFever
                   ? '0 2px 12px rgba(255, 140, 0, 0.3)'
@@ -88,7 +88,7 @@ function UnlockedBananaTiers({
                 style={{
                   fontSize: '0.65rem',
                   fontWeight: 700,
-                  color: '#ff8c00',
+                  color: 'var(--special-nui)',
                   marginLeft: 'auto',
                   paddingLeft: 8,
                   opacity: 0.8,
@@ -105,13 +105,13 @@ function UnlockedBananaTiers({
                 padding: '6px 14px',
                 fontSize: '0.75rem',
                 fontWeight: 800,
-                color: '#9333ea',
+                color: 'var(--special-magic)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: 8,
                 userSelect: 'none',
                 transition: 'all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                borderLeft: '3px solid #a855f7',
+                borderLeft: '3px solid var(--special-magic-light)',
                 background: isAllGiant
                   ? 'rgba(168, 85, 247, 0.15)'
                   : 'rgba(255, 255, 255, 0.8)',
@@ -130,7 +130,7 @@ function UnlockedBananaTiers({
                 style={{
                   fontSize: '0.65rem',
                   fontWeight: 700,
-                  color: '#a855f7',
+                  color: 'var(--special-magic-light)',
                   marginLeft: 'auto',
                   paddingLeft: 8,
                   opacity: 0.8,
@@ -147,13 +147,13 @@ function UnlockedBananaTiers({
                 padding: '6px 14px',
                 fontSize: '0.75rem',
                 fontWeight: 800,
-                color: '#1e3a5f',
+                color: 'var(--special-blackhole-dark)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: 8,
                 userSelect: 'none',
                 transition: 'all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                borderLeft: '3px solid #3b82f6',
+                borderLeft: '3px solid var(--special-blackhole)',
                 background: 'rgba(255, 255, 255, 0.8)',
                 boxShadow: '0 2px 10px rgba(0,0,0,0.05)',
               }}
@@ -168,7 +168,7 @@ function UnlockedBananaTiers({
                 style={{
                   fontSize: '0.65rem',
                   fontWeight: 700,
-                  color: '#3b82f6',
+                  color: 'var(--special-blackhole)',
                   marginLeft: 'auto',
                   paddingLeft: 8,
                   opacity: 0.8,
@@ -185,13 +185,13 @@ function UnlockedBananaTiers({
                 padding: '6px 14px',
                 fontSize: '0.75rem',
                 fontWeight: 800,
-                color: '#e11d48',
+                color: 'var(--special-onekind)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: 8,
                 userSelect: 'none',
                 transition: 'all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                borderLeft: '3px solid #e11d48',
+                borderLeft: '3px solid var(--special-onekind)',
                 background: isOneKind
                   ? 'rgba(225, 29, 72, 0.15)'
                   : 'rgba(255, 255, 255, 0.8)',
@@ -210,7 +210,7 @@ function UnlockedBananaTiers({
                 style={{
                   fontSize: '0.65rem',
                   fontWeight: 700,
-                  color: '#e11d48',
+                  color: 'var(--special-onekind)',
                   marginLeft: 'auto',
                   paddingLeft: 8,
                   opacity: 0.8,

--- a/src/components/ui/UpgradeGroupCard.jsx
+++ b/src/components/ui/UpgradeGroupCard.jsx
@@ -31,7 +31,7 @@ function UpgradeGroupCard({
           borderRadius: 12,
           border: `1.5px solid ${
             isMaxed
-              ? 'rgba(76,175,80,0.35)'
+              ? 'var(--status-maxed-border)'
               : affordable
                 ? 'var(--accent-gold)'
                 : 'rgba(0,0,0,0.08)'
@@ -109,7 +109,7 @@ function UpgradeGroupCard({
             padding: '5px 7px 4px',
             borderBottom: `1px solid ${
               isMaxed
-                ? 'rgba(76,175,80,0.12)'
+                ? 'var(--status-maxed-bg)'
                 : affordable
                   ? 'rgba(212,175,55,0.18)'
                   : 'rgba(0,0,0,0.05)'
@@ -124,7 +124,7 @@ function UpgradeGroupCard({
               style={{
                 fontSize: '0.58rem',
                 fontWeight: 700,
-                color: isMaxed ? '#4caf50' : 'var(--text-muted)',
+                color: isMaxed ? 'var(--status-maxed)' : 'var(--text-muted)',
                 letterSpacing: '0.03em',
                 whiteSpace: 'nowrap',
               }}
@@ -143,7 +143,7 @@ function UpgradeGroupCard({
                   ? 'var(--accent-gold)'
                   : 'rgba(0,0,0,0.3)',
               background: isMaxed
-                ? 'rgba(76,175,80,0.1)'
+                ? 'var(--status-maxed-bg)'
                 : affordable
                   ? 'rgba(212,175,55,0.14)'
                   : 'rgba(0,0,0,0.05)',
@@ -176,7 +176,7 @@ function UpgradeGroupCard({
               style={{
                 fontSize: '0.65rem',
                 fontWeight: 800,
-                color: '#4caf50',
+                color: 'var(--status-maxed)',
                 letterSpacing: '0.08em',
               }}
             >
@@ -286,7 +286,7 @@ function UpgradeGroupCard({
               left: 0,
               right: 0,
               height: 6,
-              background: 'rgba(0,0,0,0.07)',
+              background: 'var(--progress-bg)',
             }}
           >
             <div
@@ -294,7 +294,7 @@ function UpgradeGroupCard({
                 height: '100%',
                 width: `${progress}%`,
                 background: affordable
-                  ? 'linear-gradient(to right, #ffe57a, #f4b400)'
+                  ? 'linear-gradient(to right, var(--accent-gold-light), var(--accent-gold))'
                   : 'linear-gradient(to right, #ddd0a0, #c8a830)',
                 transition: 'width 0.5s cubic-bezier(0.2, 0.8, 0.2, 1)',
                 boxShadow:

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,53 @@
   --glass-border: rgba(255, 255, 255, 0.8);
   --shadow-soft: 0 8px 32px 0 rgba(132, 122, 100, 0.15);
 
+  /* Gold variants */
+  --accent-gold-dark: #b8860b;
+  --accent-gold-light: #ffe066;
+  --accent-gold-glow: rgba(212, 175, 55, 0.25);
+
+  /* Special banana type colors */
+  --special-nui: #ff8c00;
+  --special-nui-light: rgba(255, 140, 0, 0.15);
+  --special-magic: #9333ea;
+  --special-magic-light: #a855f7;
+  --special-blackhole: #3b82f6;
+  --special-blackhole-dark: #1e3a5f;
+  --special-onekind: #e11d48;
+
+  /* Status colors */
+  --status-maxed: #4caf50;
+  --status-maxed-light: #8bc34a;
+  --status-maxed-bg: rgba(76, 175, 80, 0.1);
+  --status-maxed-border: rgba(76, 175, 80, 0.35);
+
+  /* Tree stage greens */
+  --tree-green-1: #8bc34a;
+  --tree-green-2: #7cb342;
+  --tree-green-3: #558b2f;
+  --tree-green-4: #4caf50;
+  --tree-green-5: #388e3c;
+  --tree-green-6: #a5d240;
+
+  /* Progress & disabled */
+  --progress-bg: rgba(0, 0, 0, 0.07);
+  --disabled-bg: #f5f5f5;
+  --disabled-text: #bbb;
+
+  /* Pending / skill-unlock state */
+  --pending-orange: #ff9800;
+  --pending-orange-dark: #f57c00;
+  --pending-orange-light: #ffb74d;
+
+  /* Shop effect text colors */
+  --effect-spawn-chance: #1e3a5f;
+  --effect-spawn-chance-next: #3b82f6;
+  --effect-onekind: #0369a1;
+  --effect-onekind-next: #0284c7;
+
+  /* Ripple color */
+  --ripple-color: rgba(255, 200, 0, 0.9);
+
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -126,7 +173,7 @@ body {
   opacity: 0.4;
   cursor: not-allowed;
   filter: grayscale(1);
-  background: #f5f5f5;
+  background: var(--disabled-bg);
   border-color: #ddd;
 }
 


### PR DESCRIPTION
## 概要
ツリーブロックのスキル選択UIがアップグレードバーに被っていた問題を修正。スキル選択パネルをツリーパネルの右横に分離して配置するように変更。

## 変更内容
- BananaTree のレイアウトをラッパー div（`flexDirection: row`）で囲み、ツリーパネルとスキル選択パネルを横並びに配置
- スキル選択パネルをツリーパネル内部から外に分離し、独立した glass-panel として表示
- ラッパーに `pointerEvents: none`、各パネルに `pointerEvents: auto` を設定しクリック透過を適切に制御
- ハードコードされた色値を CSS 変数に置換（`index.css` にツリー用・状態用の変数を追加）
- 各UIコンポーネント（ScoreDisplay, ShopModal, UnlockedBananaTiers, UpgradeGroupCard, ClickRipple）のハードコード色をCSS変数に統一

## 備考
- Lint エラーは `.claude/skills/` 内の評価用ファイルのみで、src 配下にはエラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スキル選択パネルをバナナツリー下部に浮遊型として追加し、スライドインアニメーション対応。

* **Style**
  * UI全体の色設計をCSS変数ベースのシステムに統一。複数コンポーネント間で一貫性のあるテーマカラーを実装。
  * ツリーパネルのレイアウトと相互作用のビジュアル効果を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->