### PR TITLE
Acquired tree skills overlap upgrade bar when too many skills

### DIFF
--- a/src/components/ui/BananaTree.jsx
+++ b/src/components/ui/BananaTree.jsx
@@ -153,6 +153,8 @@ export default function BananaTree({
           gap: 10,
           userSelect: 'none',
           width: 160,
+          maxHeight: 'calc(100vh - 130px - 120px)',
+          boxSizing: 'border-box',
           borderRadius: '24px',
           border: isGold
             ? '1px solid var(--accent-gold-soft)'
@@ -221,6 +223,8 @@ export default function BananaTree({
             display: 'flex',
             flexDirection: 'column',
             gap: 8,
+            flex: 1,
+            minHeight: 0,
           }}
         >
           {/* Growth bar + coin goal */}
@@ -364,6 +368,9 @@ export default function BananaTree({
               display: 'flex',
               flexDirection: 'column',
               gap: 6,
+              flex: 1,
+              minHeight: 0,
+              overflowY: 'auto',
             }}
           >
             {/* ── ステージ進捗ドット ── */}

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,14 @@ body {
   border-radius: 16px;
 }
 
+/* ツリーパネル内スキルセクションのスクロールバーを非表示 */
+.glass-panel *::-webkit-scrollbar {
+  display: none;
+}
+.glass-panel * {
+  scrollbar-width: none;
+}
+
 /* バナナドラッグ中はUI要素がマウスイベントを奪わないようにする */
 .banana-dragging .glass-panel,
 .banana-dragging .banana-ui-block {


### PR DESCRIPTION
## 概要
ツリーパネル下部の取得済みスキル一覧が増えると、画面下部のアップグレードバーと重なる問題を修正。

## 関連イシュー
Closes #74

## 変更内容
- ツリーパネル（glass-panel）に `maxHeight: calc(100vh - 130px - 120px)` を設定し、アップグレードバーとの重なりを防止
- info column と skills section に `flex: 1, minHeight: 0` を追加し、flex制約を正しく伝搬
- skills section に `overflowY: auto` を追加し、スキルが多い場合はスクロール可能に
- glass-panel 内要素のスクロールバーを非表示にするCSSを追加

## 備考
- 水やりボタン等の上部UIは固定されたまま、スキル一覧部分のみスクロールする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * スキルパネルのスクロール動作を改善し、ビューポート内での表示を最適化しました。
  * パネルのスクロールバー表示を調整し、より洗練されたインターフェースを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->