### PR TITLE
Fix dev mode banana selection affecting auto-spawn

### DIFF
--- a/src/components/BananaWorld.jsx
+++ b/src/components/BananaWorld.jsx
@@ -125,20 +125,9 @@ const BananaWorld = forwardRef(
       ],
     );
 
-    const spawnBananaWithCheck = useCallback(
+    // 通常スポーン（oneKind判定 + 通常ランダム）
+    const spawnNormal = useCallback(
       (x) => {
-        // デバッグモード: 固定バナナが選択されている場合
-        const forced = debugForcedBananaRef.current;
-        if (forced) {
-          if (forced.type === 'tier') {
-            spawnBanana(x, [forced.tier]);
-          } else if (forced.type === 'special') {
-            spawnSpecialBanana(x, forced.item);
-            onSpecialSpawnRef.current?.(x, forced.item.id);
-          }
-          return;
-        }
-
         const selection = isOneKindRef.current
           ? oneKindSelectionRef.current
           : null;
@@ -164,11 +153,35 @@ const BananaWorld = forwardRef(
         isOneKindRef,
         oneKindSelectionRef,
         onSpecialSpawnRef,
+      ],
+    );
+
+    // 手動クリック用: デバッグ固定バナナを優先、なければ通常スポーン
+    const spawnBananaWithCheck = useCallback(
+      (x) => {
+        const forced = debugForcedBananaRef.current;
+        if (forced) {
+          if (forced.type === 'tier') {
+            spawnBanana(x, [forced.tier]);
+          } else if (forced.type === 'special') {
+            spawnSpecialBanana(x, forced.item);
+            onSpecialSpawnRef.current?.(x, forced.item.id);
+          }
+          return;
+        }
+        spawnNormal(x);
+      },
+      [
+        spawnBanana,
+        spawnSpecialBanana,
+        spawnNormal,
+        onSpecialSpawnRef,
         debugForcedBananaRef,
       ],
     );
 
-    useAutoSpawn({ autoSpawnRate, spawnBanana: spawnBananaWithCheck });
+    // オートスポーンはデバッグ選択を無視し、常に通常スポーンを使用
+    useAutoSpawn({ autoSpawnRate, spawnBanana: spawnNormal });
 
     const handleDataClick = (e) => {
       const x = resolvePointerX(e);


### PR DESCRIPTION
## 概要
開発者モード(Shift+Ctrl+D)でバナナ種を選択すると、オートスポーンで落下するバナナ種まで固定されてしまうバグを修正。

## 関連イシュー
Closes #76

## 変更内容
- `spawnBananaWithCheck` から通常スポーン処理を `spawnNormal` として分離
- `useAutoSpawn` に `spawnNormal` を渡し、デバッグ選択を無視するように変更
- 手動クリック時のみデバッグ固定バナナが適用される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 自動スポーン時のデバッグ強制バナナ処理を改善しました。デバッグモードでの手動操作と自動スポーンの動作が更に明確に区別されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->