### PR TITLE
Set up Terraform foundation and S3 + CloudFront static hosting

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,0 +1,54 @@
+name: Deploy Frontend (AWS)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.js'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: 'deploy-aws'
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync to S3
+        run: aws s3 sync dist/ s3://${{ vars.FRONTEND_BUCKET }} --delete
+
+      - name: Invalidate CloudFront Cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -61,9 +61,12 @@ jobs:
           PLAN_OUTPUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
-            const plan = (process.env.PLAN_OUTPUT || '').slice(0, 60000);
+            const fullPlan = process.env.PLAN_OUTPUT || '';
+            const truncated = fullPlan.length > 60000;
+            const plan = fullPlan.slice(0, 60000);
             const body = [
               '#### Terraform Plan',
+              truncated ? '⚠️ Plan output was truncated (exceeds 60,000 characters)' : '',
               '<details><summary>Show Plan</summary>',
               '',
               '```',
@@ -71,7 +74,7 @@ jobs:
               '```',
               '',
               '</details>',
-            ].join('\n');
+            ].filter(Boolean).join('\n');
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,84 @@
+name: Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  TF_VERSION: '1.12'
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.INFRA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Format Check
+        run: terraform fmt -check
+
+      - name: Terraform Validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -out=tfplan
+
+      - name: Comment Plan on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PLAN_OUTPUT: ${{ steps.plan.outputs.stdout }}
+        with:
+          script: |
+            const plan = (process.env.PLAN_OUTPUT || '').slice(0, 60000);
+            const body = [
+              '#### Terraform Plan',
+              '<details><summary>Show Plan</summary>',
+              '',
+              '```',
+              plan,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist-ssr
 # Claude Code
 .claude/
 
+# Terraform
+infra/.terraform/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ dist-ssr
 
 # Terraform
 infra/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
 
 # Editor directories and files
 .vscode/*

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # NOTE: bucket name must match "${var.project_name}-tfstate" (default: bananadrop-tfstate).
+  # Backend blocks do not support variables — keep in sync manually.
+  backend "s3" {
+    bucket       = "bananadrop-tfstate"
+    key          = "bananadrop/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -1,0 +1,52 @@
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  default_root_object = "index.html"
+  comment             = var.project_name
+
+  # S3 Origin (static files)
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "s3-frontend"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # Default behavior (S3)
+  default_cache_behavior {
+    target_origin_id       = "s3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    # AWS Managed Cache Policy: CachingOptimized (Gzip + Brotli)
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  # SPA fallback: 403/404 -> /index.html
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  # Use edge locations in North America, Europe, Asia — no South America/Africa
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,201 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  oidc_provider_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+}
+
+# --- infra.yml role (Terraform apply) ---
+
+resource "aws_iam_role" "github_actions_infra" {
+  name = "${var.project_name}-github-actions-infra"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Infra role: tfstate access
+resource "aws_iam_role_policy" "infra_tfstate" {
+  name = "tfstate-access"
+  role = aws_iam_role.github_actions_infra.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.project_name}-tfstate",
+          "arn:aws:s3:::${var.project_name}-tfstate/*",
+        ]
+      }
+    ]
+  })
+}
+
+# Infra role: manage AWS resources
+# Scope to Phase 1 (S3 + CloudFront + IAM). Expand as later phases land.
+resource "aws_iam_role_policy" "infra_resources" {
+  name = "infra-resources"
+  role = aws_iam_role.github_actions_infra.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3Management"
+        Effect = "Allow"
+        Action = [
+          "s3:CreateBucket",
+          "s3:DeleteBucket",
+          "s3:Get*",
+          "s3:List*",
+          "s3:Put*",
+          "s3:DeleteObject",
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.project_name}-*",
+          "arn:aws:s3:::${var.project_name}-*/*",
+        ]
+      },
+      {
+        # CreateDistribution, ListOriginAccessControls 等はリソースレベルの制限を
+        # サポートしていないため Resource = "*" が必要
+        Sid    = "CloudFrontManagement"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateDistribution",
+          "cloudfront:DeleteDistribution",
+          "cloudfront:GetDistribution",
+          "cloudfront:GetDistributionConfig",
+          "cloudfront:UpdateDistribution",
+          "cloudfront:TagResource",
+          "cloudfront:UntagResource",
+          "cloudfront:ListTagsForResource",
+          "cloudfront:CreateOriginAccessControl",
+          "cloudfront:DeleteOriginAccessControl",
+          "cloudfront:GetOriginAccessControl",
+          "cloudfront:UpdateOriginAccessControl",
+          "cloudfront:ListOriginAccessControls",
+          "cloudfront:CreateInvalidation",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IAMRoleManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:UpdateRole",
+          "iam:PassRole",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListInstanceProfilesForRole",
+          "iam:PutRolePolicy",
+          "iam:GetRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+        ]
+        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.project_name}-*"
+      },
+    ]
+  })
+}
+
+# --- deploy.yml role (S3 sync + CloudFront invalidation) ---
+
+resource "aws_iam_role" "github_actions_deploy" {
+  name = "${var.project_name}-github-actions-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "deploy_s3_sync" {
+  name = "s3-sync"
+  role = aws_iam_role.github_actions_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.frontend.arn,
+          "${aws_s3_bucket.frontend.arn}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "deploy_cloudfront_invalidation" {
+  name = "cloudfront-invalidation"
+  role = aws_iam_role.github_actions_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+        ]
+        Resource = aws_cloudfront_distribution.main.arn
+      }
+    ]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,24 @@
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront domain name"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "s3_bucket_name" {
+  description = "Frontend S3 bucket name"
+  value       = aws_s3_bucket.frontend.id
+}
+
+output "github_actions_infra_role_arn" {
+  description = "IAM role ARN for infra.yml"
+  value       = aws_iam_role.github_actions_infra.arn
+}
+
+output "github_actions_deploy_role_arn" {
+  description = "IAM role ARN for deploy.yml"
+  value       = aws_iam_role.github_actions_deploy.arn
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -2,6 +2,14 @@ resource "aws_s3_bucket" "frontend" {
   bucket = "${var.project_name}-frontend"
 }
 
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,41 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.project_name}-frontend"
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontOAC"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.main.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project_name}-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -8,10 +8,18 @@ variable "project_name" {
   description = "Project name used for resource naming"
   type        = string
   default     = "bananadrop"
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.project_name))
+    error_message = "project_name must contain only lowercase letters, numbers, and hyphens."
+  }
 }
 
 variable "github_repo" {
   description = "GitHub repository in owner/repo format"
   type        = string
   default     = "yuyumama/bananadrop"
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repo))
+    error_message = "github_repo must be in owner/repo format."
+  }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "bananadrop"
+}
+
+variable "github_repo" {
+  description = "GitHub repository in owner/repo format"
+  type        = string
+  default     = "yuyumama/bananadrop"
+}


### PR DESCRIPTION
## 概要

GitHub Pages から CloudFront + S3 への静的ホスティング移行のための Terraform 基盤セットアップ（Phase 1）。

## 関連イシュー

Closes #86

## 変更内容

- **`infra/`**: Terraform設定を新規追加
  - S3バケット（OAC経由、パブリックアクセス完全ブロック）
  - CloudFrontディストリビューション（SPA対応、PriceClass_200）
  - IAMロール2種（OIDC認証、mainブランチのみに制限）
    - `infra`: Terraform plan/apply用
    - `deploy`: S3 sync + CloudFrontキャッシュ無効化用
  - S3バックエンドによるtfstate管理（ネイティブロック使用）
- **`.github/workflows/infra.yml`**: Terraform CI（fmt check → validate → plan → PRコメント → apply）
- **`.github/workflows/deploy-aws.yml`**: S3 sync + CloudFrontキャッシュ無効化ワークフロー
- **`.gitignore`**: `infra/.terraform/` を追加
- 既存の `deploy.yml`（GitHub Pages）はそのまま維持

## 備考

- 初回のみローカルから `terraform apply` を実行し、outputされるロールARN等をGitHub Variables に設定する必要あり
- tfstateバケット（`bananadrop-tfstate`）は事前に手動作成が必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * フロントエンドの自動デプロイパイプラインを追加しました（手動トリガー対応）。
  * AWS上でフロントエンドをホストするインフラを構築しました（S3＋CloudFront、配信無効化含む）。
  * インフラをコード化（Terraform）し、状態管理・バージョン固定・入力検証を導入しました。
  * GitHub Actions用の限定的な実行権限を持つIAMロールを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->