### PR TITLE
Add Cognito authentication and login UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Cognito settings (from Terraform outputs)
+VITE_COGNITO_REGION=ap-northeast-1
+VITE_COGNITO_USER_POOL_ID=
+VITE_COGNITO_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Cognito settings (from Terraform outputs)
+VITE_COGNITO_CLIENT_ID=
 VITE_COGNITO_REGION=ap-northeast-1
 VITE_COGNITO_USER_POOL_ID=
-VITE_COGNITO_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ dist-ssr
 # Claude Code
 .claude/
 
+# Playwright MCP
+.playwright-mcp/
+
 # Terraform
 infra/.terraform/
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
+.env.*
+!.env.example
 
 # Claude Code
 .claude/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 バナナを落として、スコアを稼ぐブラウザゲームです。
 
 **▶ [今すぐ遊ぶ](https://yuyumama.github.io/bananadrop/)**
-**▶ [AWS環境*メンテ中](https://d28dbgr2bbmfim.cloudfront.net/)**
+**▶ [AWS環境\*メンテ中](https://d28dbgr2bbmfim.cloudfront.net/)**
 
 ---
 

--- a/infra/cognito.tf
+++ b/infra/cognito.tf
@@ -1,0 +1,78 @@
+# Cognito User Pool
+resource "aws_cognito_user_pool" "main" {
+  name = var.project_name
+
+  # Email sign-up
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  # Password policy (Cognito defaults)
+  password_policy {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+
+  # MFA disabled (per architecture doc)
+  mfa_configuration = "OFF"
+
+  # Email verification message
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_subject        = "${var.project_name} - Verification Code"
+    email_message        = "Your verification code is {####}"
+  }
+
+  # Schema: email is required
+  schema {
+    name                = "email"
+    attribute_data_type = "String"
+    required            = true
+    mutable             = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  # Account recovery via email
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+}
+
+# App Client (SPA - no client secret)
+resource "aws_cognito_user_pool_client" "spa" {
+  name         = "${var.project_name}-spa"
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  # No client secret for SPA
+  generate_secret = false
+
+  # Auth flows
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+
+  # Token expiry (per architecture doc: Access 1h, Refresh 30d)
+  access_token_validity  = 1
+  id_token_validity      = 1
+  refresh_token_validity = 30
+
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  # Prevent user existence errors (security best practice)
+  prevent_user_existence_errors = "ENABLED"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -22,3 +22,13 @@ output "github_actions_deploy_role_arn" {
   description = "IAM role ARN for deploy.yml"
   value       = aws_iam_role.github_actions_deploy.arn
 }
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = aws_cognito_user_pool.main.id
+}
+
+output "cognito_client_id" {
+  description = "Cognito App Client ID"
+  value       = aws_cognito_user_pool_client.spa.id
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "banana",
       "version": "0.0.0",
       "dependencies": {
+        "amazon-cognito-identity-js": "^6.3.16",
         "jimp": "^1.6.0",
         "lucide-react": "^0.575.0",
         "matter-js": "^0.20.0",
@@ -27,6 +28,62 @@
         "prettier": "^3.8.1",
         "vite": "^7.2.4"
       }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1882,6 +1939,24 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/types": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -2038,6 +2113,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/amazon-cognito-identity-js": {
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.16.tgz",
+      "integrity": "sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
+    "node_modules/amazon-cognito-identity-js/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -2614,6 +2713,12 @@
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2904,12 +3009,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "node_modules/jimp": {
       "version": "1.6.0",
@@ -2954,6 +3075,12 @@
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3151,6 +3278,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -3704,6 +3851,18 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3716,6 +3875,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3840,6 +4005,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "amazon-cognito-identity-js": "^6.3.16",
     "jimp": "^1.6.0",
     "lucide-react": "^0.575.0",
     "matter-js": "^0.20.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ const MAX_SPAWN_FLASHES = 3;
 const MAX_FEVER_BURSTS = 3;
 
 function App() {
-  const { signOut, user } = useAuth();
+  const { signOut, user, authEnabled } = useAuth();
   const [score, setScore] = useState(0);
   const {
     bananaPerClick,
@@ -375,7 +375,9 @@ function App() {
   const effectiveGiantChance = isAllGiant ? 1 : giantChance;
 
   return (
-    <div
+    <main
+      role="application"
+      aria-label="バナナドロップ ゲーム"
       style={{
         position: 'relative',
         width: '100%',
@@ -384,30 +386,34 @@ function App() {
       }}
       onClick={handleClick}
     >
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          signOut();
-        }}
-        style={{
-          position: 'fixed',
-          top: 10,
-          right: 10,
-          zIndex: 1000,
-          padding: '6px 14px',
-          borderRadius: '8px',
-          border: '1px solid var(--glass-border)',
-          background: 'var(--glass-bg)',
-          backdropFilter: 'blur(8px)',
-          color: 'var(--text-muted)',
-          fontSize: '12px',
-          fontWeight: 600,
-          cursor: 'pointer',
-        }}
-        title={user?.email}
-      >
-        Logout
-      </button>
+      {authEnabled && (
+        <button
+          className="logout-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            signOut();
+          }}
+          aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
+          title={user?.email}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+          <span>Logout</span>
+        </button>
+      )}
       <ScoreDisplay
         score={score}
         perSecond={perSecond}
@@ -470,6 +476,9 @@ function App() {
 
           {/* 中央フローティングラベル */}
           <div
+            className="effect-status-label"
+            role="status"
+            aria-label={`ぬいバナナフィーバー 残り${feverRemaining}秒`}
             style={{
               position: 'fixed',
               top: 10,
@@ -493,7 +502,9 @@ function App() {
               letterSpacing: '0.04em',
             }}
           >
-            <span style={{ fontSize: '0.85rem' }}>🔥</span>
+            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
+              🔥
+            </span>
             <span>ぬいバナナ</span>
             <span
               style={{
@@ -538,6 +549,9 @@ function App() {
             />
           </div>
           <div
+            className="effect-status-label"
+            role="status"
+            aria-label={`マジックバナナ 残り${allGiantRemaining}秒`}
             style={{
               position: 'fixed',
               top: isFever ? 36 : 10,
@@ -561,7 +575,9 @@ function App() {
               letterSpacing: '0.04em',
             }}
           >
-            <span style={{ fontSize: '0.85rem' }}>✨</span>
+            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
+              ✨
+            </span>
             <span>マジックバナナ</span>
             <span
               style={{
@@ -606,6 +622,9 @@ function App() {
             />
           </div>
           <div
+            className="effect-status-label"
+            role="status"
+            aria-label={`oneバナナ 残り${oneKindRemaining}秒`}
             style={{
               position: 'fixed',
               top: 10 + [isFever, isAllGiant].filter(Boolean).length * 26,
@@ -629,7 +648,9 @@ function App() {
               letterSpacing: '0.04em',
             }}
           >
-            <span style={{ fontSize: '0.85rem' }}>🍌</span>
+            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
+              🍌
+            </span>
             <span>oneバナナ</span>
             <span
               style={{
@@ -749,7 +770,7 @@ function App() {
         treeMutationRateBonus={treeMutationRateBonus}
         treeCriticalClickChance={treeCriticalClickChance}
       />
-    </div>
+    </main>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -376,7 +376,6 @@ function App() {
 
   return (
     <main
-      role="application"
       aria-label="バナナドロップ ゲーム"
       style={{
         position: 'relative',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { useAuth } from './hooks/useAuth';
 import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
 import FeverBurst from './components/ui/FeverBurst';
@@ -32,6 +33,7 @@ const MAX_SPAWN_FLASHES = 3;
 const MAX_FEVER_BURSTS = 3;
 
 function App() {
+  const { signOut, user } = useAuth();
   const [score, setScore] = useState(0);
   const {
     bananaPerClick,
@@ -382,6 +384,30 @@ function App() {
       }}
       onClick={handleClick}
     >
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          signOut();
+        }}
+        style={{
+          position: 'fixed',
+          top: 10,
+          right: 10,
+          zIndex: 1000,
+          padding: '6px 14px',
+          borderRadius: '8px',
+          border: '1px solid var(--glass-border)',
+          background: 'var(--glass-bg)',
+          backdropFilter: 'blur(8px)',
+          color: 'var(--text-muted)',
+          fontSize: '12px',
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+        title={user?.email}
+      >
+        Logout
+      </button>
       <ScoreDisplay
         score={score}
         perSecond={perSecond}

--- a/src/components/auth/AuthGate.jsx
+++ b/src/components/auth/AuthGate.jsx
@@ -6,7 +6,12 @@ export default function AuthGate({ children }) {
 
   if (isLoading) {
     return (
-      <div style={styles.loading}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="読み込み中"
+        style={styles.loading}
+      >
         <div style={styles.loaderWrap}>
           <img
             src={`${import.meta.env.BASE_URL}banana_gold_01.png`}

--- a/src/components/auth/AuthGate.jsx
+++ b/src/components/auth/AuthGate.jsx
@@ -44,7 +44,7 @@ const styles = {
   loaderBanana: {
     width: '48px',
     height: 'auto',
-    animation: 'bananaFloat 1.5s ease-in-out infinite',
+    animation: 'banana-float 1.5s ease-in-out infinite',
     filter: 'drop-shadow(0 6px 12px rgba(212, 175, 55, 0.3))',
   },
   loaderDot: {
@@ -52,6 +52,6 @@ const styles = {
     height: '4px',
     borderRadius: '2px',
     background: 'rgba(212, 175, 55, 0.2)',
-    animation: 'loaderPulse 1.5s ease-in-out infinite',
+    animation: 'loader-pulse 1.5s ease-in-out infinite',
   },
 };

--- a/src/components/auth/AuthGate.jsx
+++ b/src/components/auth/AuthGate.jsx
@@ -1,0 +1,57 @@
+import { useAuth } from '../../hooks/useAuth';
+import AuthScreen from './AuthScreen';
+
+export default function AuthGate({ children }) {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div style={styles.loading}>
+        <div style={styles.loaderWrap}>
+          <img
+            src={`${import.meta.env.BASE_URL}banana_gold_01.png`}
+            alt=""
+            style={styles.loaderBanana}
+          />
+          <div style={styles.loaderDot} />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <AuthScreen />;
+  }
+
+  return children;
+}
+
+const styles = {
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    background:
+      'radial-gradient(ellipse at 50% 20%, #fff9e6 0%, #fcfaf5 50%, #f5efe0 100%)',
+  },
+  loaderWrap: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '16px',
+  },
+  loaderBanana: {
+    width: '48px',
+    height: 'auto',
+    animation: 'bananaFloat 1.5s ease-in-out infinite',
+    filter: 'drop-shadow(0 6px 12px rgba(212, 175, 55, 0.3))',
+  },
+  loaderDot: {
+    width: '24px',
+    height: '4px',
+    borderRadius: '2px',
+    background: 'rgba(212, 175, 55, 0.2)',
+    animation: 'loaderPulse 1.5s ease-in-out infinite',
+  },
+};

--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -28,7 +28,7 @@ function FallingBanana({ delay, left, duration, size, rotation, image }) {
         height: 'auto',
         opacity: 0.35,
         pointerEvents: 'none',
-        animation: `bananaFall ${duration}s linear ${delay}s infinite`,
+        animation: `banana-fall ${duration}s linear ${delay}s infinite`,
         transform: `rotate(${rotation}deg)`,
         filter: 'blur(1px)',
       }}
@@ -225,7 +225,7 @@ const styles = {
   heroImg: {
     width: '72px',
     height: 'auto',
-    animation: 'bananaFloat 3s ease-in-out infinite',
+    animation: 'banana-float 3s ease-in-out infinite',
   },
   titleWrap: {
     textAlign: 'center',
@@ -271,9 +271,9 @@ const styles = {
     opacity: 0,
   },
   slideInRight: {
-    animation: 'authSlideInRight 0.3s ease forwards',
+    animation: 'auth-slide-in-right 0.3s ease forwards',
   },
   slideInLeft: {
-    animation: 'authSlideInLeft 0.3s ease forwards',
+    animation: 'auth-slide-in-left 0.3s ease forwards',
   },
 };

--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useRef } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+import LoginForm from './LoginForm';
+import SignupForm from './SignupForm';
+import ConfirmForm from './ConfirmForm';
+
+const BANANA_IMAGES = [
+  'banana_ripe_01.png',
+  'banana_ripe_02.png',
+  'banana_gold_01.png',
+  'banana_gold_02.png',
+  'banana_green_01.png',
+  'banana_green_02.png',
+  'banana_red_01.png',
+  'banana_copper_01.png',
+];
+
+function FallingBanana({ delay, left, duration, size, rotation, image }) {
+  return (
+    <img
+      src={`${import.meta.env.BASE_URL}${image}`}
+      alt=""
+      style={{
+        position: 'absolute',
+        top: '-60px',
+        left: `${left}%`,
+        width: `${size}px`,
+        height: 'auto',
+        opacity: 0.35,
+        pointerEvents: 'none',
+        animation: `bananaFall ${duration}s linear ${delay}s infinite`,
+        transform: `rotate(${rotation}deg)`,
+        filter: 'blur(1px)',
+      }}
+    />
+  );
+}
+
+function FallingBananas() {
+  const [bananas] = useState(() =>
+    Array.from({ length: 12 }, (_, i) => ({
+      id: i,
+      delay: Math.random() * 8,
+      left: Math.random() * 100,
+      duration: 6 + Math.random() * 6,
+      size: 24 + Math.random() * 28,
+      rotation: Math.random() * 360,
+      image: BANANA_IMAGES[Math.floor(Math.random() * BANANA_IMAGES.length)],
+    })),
+  );
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'hidden',
+        pointerEvents: 'none',
+      }}
+    >
+      {bananas.map((b) => (
+        <FallingBanana key={b.id} {...b} />
+      ))}
+    </div>
+  );
+}
+
+export default function AuthScreen() {
+  const { signIn, signUp, confirmSignUp } = useAuth();
+  const [view, setView] = useState('login');
+  const [error, setError] = useState('');
+  const [confirmEmail, setConfirmEmail] = useState('');
+  const [slideDir, setSlideDir] = useState('none');
+  const cardRef = useRef(null);
+
+  const animateTransition = (newView, dir) => {
+    setSlideDir(dir);
+    setError('');
+    setTimeout(() => {
+      setView(newView);
+      setSlideDir(dir === 'left' ? 'enter-right' : 'enter-left');
+      setTimeout(() => setSlideDir('none'), 300);
+    }, 200);
+  };
+
+  const handleSignIn = async (email, password) => {
+    setError('');
+    try {
+      await signIn(email, password);
+    } catch (err) {
+      setError(err.message || 'ログインに失敗しました');
+    }
+  };
+
+  const handleSignUp = async (email, password) => {
+    setError('');
+    try {
+      await signUp(email, password);
+      setConfirmEmail(email);
+      animateTransition('confirm', 'left');
+    } catch (err) {
+      setError(err.message || 'アカウント作成に失敗しました');
+    }
+  };
+
+  const handleConfirm = async (email, code) => {
+    setError('');
+    try {
+      await confirmSignUp(email, code);
+      animateTransition('login', 'right');
+    } catch (err) {
+      setError(err.message || '認証コードが正しくありません');
+    }
+  };
+
+  // Bounce the hero banana on mount
+  const [heroLoaded, setHeroLoaded] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setHeroLoaded(true), 100);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div style={styles.backdrop}>
+      <FallingBananas />
+
+      <div style={styles.container}>
+        {/* Hero banana */}
+        <div
+          style={{
+            ...styles.heroBanana,
+            transform: heroLoaded
+              ? 'translateY(0) scale(1) rotate(-8deg)'
+              : 'translateY(-30px) scale(0.5) rotate(-30deg)',
+            opacity: heroLoaded ? 1 : 0,
+          }}
+        >
+          <img
+            src={`${import.meta.env.BASE_URL}banana_gold_01.png`}
+            alt="BananaDrop"
+            style={styles.heroImg}
+          />
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            ...styles.titleWrap,
+            transform: heroLoaded ? 'translateY(0)' : 'translateY(10px)',
+            opacity: heroLoaded ? 1 : 0,
+          }}
+        >
+          <h1 style={styles.title}>BananaDrop</h1>
+        </div>
+
+        {/* Card */}
+        <div
+          ref={cardRef}
+          style={{
+            ...styles.card,
+            ...(slideDir === 'left' && styles.slideOutLeft),
+            ...(slideDir === 'right' && styles.slideOutRight),
+            ...(slideDir === 'enter-right' && styles.slideInRight),
+            ...(slideDir === 'enter-left' && styles.slideInLeft),
+          }}
+        >
+          {view === 'login' && (
+            <LoginForm
+              onSubmit={handleSignIn}
+              onSwitchToSignup={() => animateTransition('signup', 'left')}
+              error={error}
+            />
+          )}
+
+          {view === 'signup' && (
+            <SignupForm
+              onSubmit={handleSignUp}
+              onSwitchToLogin={() => animateTransition('login', 'right')}
+              error={error}
+            />
+          )}
+
+          {view === 'confirm' && (
+            <ConfirmForm
+              email={confirmEmail}
+              onSubmit={handleConfirm}
+              onBack={() => animateTransition('login', 'right')}
+              error={error}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  backdrop: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    background:
+      'radial-gradient(ellipse at 50% 20%, #fff9e6 0%, #fcfaf5 50%, #f5efe0 100%)',
+    padding: '20px',
+    overflow: 'hidden',
+  },
+  container: {
+    position: 'relative',
+    zIndex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '0px',
+    width: '100%',
+    maxWidth: '380px',
+  },
+  heroBanana: {
+    transition: 'all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
+    marginBottom: '-8px',
+    zIndex: 2,
+    filter: 'drop-shadow(0 8px 20px rgba(212, 175, 55, 0.35))',
+  },
+  heroImg: {
+    width: '72px',
+    height: 'auto',
+    animation: 'bananaFloat 3s ease-in-out infinite',
+  },
+  titleWrap: {
+    textAlign: 'center',
+    marginBottom: '20px',
+    transition: 'all 0.5s ease 0.15s',
+  },
+  title: {
+    margin: 0,
+    fontSize: '32px',
+    fontWeight: 900,
+    letterSpacing: '-1px',
+    background:
+      'linear-gradient(135deg, #d4af37 0%, #f0d060 40%, #b8860b 100%)',
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    filter: 'drop-shadow(0 2px 4px rgba(184, 134, 11, 0.2))',
+  },
+  subtitle: {
+    margin: '4px 0 0',
+    fontSize: '13px',
+    color: '#a09070',
+    fontWeight: 500,
+    letterSpacing: '0.02em',
+  },
+  card: {
+    width: '100%',
+    padding: '28px 24px',
+    borderRadius: '20px',
+    background: 'rgba(255, 255, 255, 0.75)',
+    border: '1px solid rgba(255, 255, 255, 0.9)',
+    boxShadow:
+      '0 12px 40px rgba(132, 122, 100, 0.12), 0 0 0 1px rgba(212, 175, 55, 0.08)',
+    backdropFilter: 'blur(16px)',
+    WebkitBackdropFilter: 'blur(16px)',
+    transition: 'transform 0.2s ease, opacity 0.2s ease',
+  },
+  slideOutLeft: {
+    transform: 'translateX(-20px)',
+    opacity: 0,
+  },
+  slideOutRight: {
+    transform: 'translateX(20px)',
+    opacity: 0,
+  },
+  slideInRight: {
+    animation: 'authSlideInRight 0.3s ease forwards',
+  },
+  slideInLeft: {
+    animation: 'authSlideInLeft 0.3s ease forwards',
+  },
+};

--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import LoginForm from './LoginForm';
 import SignupForm from './SignupForm';
@@ -72,16 +72,27 @@ export default function AuthScreen() {
   const [confirmEmail, setConfirmEmail] = useState('');
   const [slideDir, setSlideDir] = useState('none');
   const cardRef = useRef(null);
+  const transitionTimers = useRef([]);
 
-  const animateTransition = (newView, dir) => {
+  useEffect(() => {
+    return () => {
+      transitionTimers.current.forEach(clearTimeout);
+    };
+  }, []);
+
+  const animateTransition = useCallback((newView, dir) => {
+    transitionTimers.current.forEach(clearTimeout);
+    transitionTimers.current = [];
     setSlideDir(dir);
     setError('');
-    setTimeout(() => {
+    const t1 = setTimeout(() => {
       setView(newView);
       setSlideDir(dir === 'left' ? 'enter-right' : 'enter-left');
-      setTimeout(() => setSlideDir('none'), 300);
+      const t2 = setTimeout(() => setSlideDir('none'), 300);
+      transitionTimers.current.push(t2);
     }, 200);
-  };
+    transitionTimers.current.push(t1);
+  }, []);
 
   const handleSignIn = async (email, password) => {
     setError('');

--- a/src/components/auth/ConfirmForm.jsx
+++ b/src/components/auth/ConfirmForm.jsx
@@ -71,13 +71,13 @@ export default function ConfirmForm({ email, onSubmit, onBack, error }) {
       </div>
 
       {error && (
-        <div style={styles.error}>
+        <div id="confirm-code-error" role="alert" style={styles.error}>
           <span style={styles.errorIcon}>!</span>
           {error}
         </div>
       )}
 
-      <div style={styles.codeRow}>
+      <div role="group" aria-label="認証コード（6桁）" style={styles.codeRow}>
         {digits.map((digit, i) => (
           <input
             key={i}
@@ -88,6 +88,9 @@ export default function ConfirmForm({ email, onSubmit, onBack, error }) {
             value={digit}
             onChange={(e) => handleDigitChange(i, e.target.value)}
             onKeyDown={(e) => handleKeyDown(i, e)}
+            aria-label={`認証コード ${i + 1} 桁目`}
+            aria-invalid={!!error}
+            aria-describedby={error ? 'confirm-code-error' : undefined}
             style={{
               ...styles.codeInput,
               borderColor: digit

--- a/src/components/auth/ConfirmForm.jsx
+++ b/src/components/auth/ConfirmForm.jsx
@@ -1,0 +1,234 @@
+import { useState, useRef, useEffect } from 'react';
+
+export default function ConfirmForm({ email, onSubmit, onBack, error }) {
+  const [digits, setDigits] = useState(['', '', '', '', '', '']);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRefs = useRef([]);
+
+  useEffect(() => {
+    inputRefs.current[0]?.focus();
+  }, []);
+
+  const handleDigitChange = (index, value) => {
+    // Handle paste of full code
+    if (value.length > 1) {
+      const pasted = value.replace(/\D/g, '').slice(0, 6).split('');
+      const newDigits = [...digits];
+      pasted.forEach((d, i) => {
+        if (index + i < 6) newDigits[index + i] = d;
+      });
+      setDigits(newDigits);
+      const nextIndex = Math.min(index + pasted.length, 5);
+      inputRefs.current[nextIndex]?.focus();
+      return;
+    }
+
+    if (!/^\d?$/.test(value)) return;
+
+    const newDigits = [...digits];
+    newDigits[index] = value;
+    setDigits(newDigits);
+
+    if (value && index < 5) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyDown = (index, e) => {
+    if (e.key === 'Backspace' && !digits[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const code = digits.join('');
+    if (code.length !== 6) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(email, code);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isComplete = digits.every((d) => d !== '');
+
+  return (
+    <form onSubmit={handleSubmit} style={styles.form}>
+      <div style={styles.iconWrap}>
+        <span style={styles.mailIcon}>📧</span>
+      </div>
+
+      <div style={styles.textCenter}>
+        <h3 style={styles.heading}>メール認証</h3>
+        <p style={styles.description}>
+          <strong style={{ color: '#4a4a4a' }}>{email}</strong> に
+          <br />
+          認証コードを送信しました
+        </p>
+      </div>
+
+      {error && (
+        <div style={styles.error}>
+          <span style={styles.errorIcon}>!</span>
+          {error}
+        </div>
+      )}
+
+      <div style={styles.codeRow}>
+        {digits.map((digit, i) => (
+          <input
+            key={i}
+            ref={(el) => (inputRefs.current[i] = el)}
+            type="text"
+            inputMode="numeric"
+            maxLength={6}
+            value={digit}
+            onChange={(e) => handleDigitChange(i, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(i, e)}
+            style={{
+              ...styles.codeInput,
+              borderColor: digit
+                ? 'rgba(212, 175, 55, 0.5)'
+                : 'rgba(212, 175, 55, 0.15)',
+              background: digit
+                ? 'rgba(255, 253, 240, 0.9)'
+                : 'rgba(255, 253, 240, 0.5)',
+            }}
+          />
+        ))}
+      </div>
+
+      <button
+        type="submit"
+        disabled={isSubmitting || !isComplete}
+        style={{
+          ...styles.button,
+          opacity: isComplete ? 1 : 0.5,
+        }}
+      >
+        {isSubmitting ? '確認中...' : '認証する'}
+      </button>
+
+      <button type="button" onClick={onBack} style={styles.backButton}>
+        ← ログインに戻る
+      </button>
+    </form>
+  );
+}
+
+const styles = {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    width: '100%',
+    alignItems: 'center',
+  },
+  iconWrap: {
+    width: '56px',
+    height: '56px',
+    borderRadius: '16px',
+    background:
+      'linear-gradient(135deg, rgba(212, 175, 55, 0.1), rgba(212, 175, 55, 0.05))',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '1px solid rgba(212, 175, 55, 0.15)',
+  },
+  mailIcon: {
+    fontSize: '28px',
+  },
+  textCenter: {
+    textAlign: 'center',
+  },
+  heading: {
+    margin: '0 0 4px',
+    fontSize: '20px',
+    fontWeight: 800,
+    color: '#4a4a4a',
+  },
+  description: {
+    margin: 0,
+    fontSize: '13px',
+    color: '#8a7a60',
+    lineHeight: 1.6,
+  },
+  codeRow: {
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'center',
+    width: '100%',
+    margin: '4px 0',
+  },
+  codeInput: {
+    width: '44px',
+    height: '52px',
+    borderRadius: '12px',
+    border: '1.5px solid rgba(212, 175, 55, 0.15)',
+    background: 'rgba(255, 253, 240, 0.5)',
+    fontSize: '22px',
+    fontWeight: 700,
+    fontFamily: "'Outfit', sans-serif",
+    color: '#4a4a4a',
+    textAlign: 'center',
+    outline: 'none',
+    transition: 'all 0.2s ease',
+    caretColor: '#d4af37',
+  },
+  button: {
+    width: '100%',
+    padding: '14px',
+    borderRadius: '14px',
+    border: 'none',
+    background:
+      'linear-gradient(135deg, #d4af37 0%, #e8c84a 50%, #b8860b 100%)',
+    color: '#fff',
+    fontSize: '16px',
+    fontWeight: 700,
+    fontFamily: "'Outfit', sans-serif",
+    cursor: 'pointer',
+    transition: 'all 0.3s ease',
+    boxShadow: '0 4px 16px rgba(212, 175, 55, 0.35)',
+  },
+  backButton: {
+    background: 'none',
+    border: 'none',
+    color: '#8a7a60',
+    fontSize: '13px',
+    fontFamily: "'Outfit', sans-serif",
+    cursor: 'pointer',
+    fontWeight: 600,
+    transition: 'color 0.2s',
+  },
+  error: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    margin: 0,
+    padding: '10px 14px',
+    borderRadius: '10px',
+    background: 'rgba(220, 38, 38, 0.06)',
+    border: '1px solid rgba(220, 38, 38, 0.12)',
+    color: '#b91c1c',
+    fontSize: '13px',
+    lineHeight: 1.4,
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  errorIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '18px',
+    height: '18px',
+    borderRadius: '50%',
+    background: '#dc2626',
+    color: '#fff',
+    fontSize: '11px',
+    fontWeight: 800,
+    flexShrink: 0,
+  },
+};

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+
+export default function LoginForm({ onSubmit, onSwitchToSignup, error }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [focusedField, setFocusedField] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await onSubmit(email, password);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={styles.form}>
+      {error && (
+        <div style={styles.error}>
+          <span style={styles.errorIcon}>!</span>
+          {error}
+        </div>
+      )}
+
+      <div style={styles.fieldGroup}>
+        <label style={styles.label}>メールアドレス</label>
+        <div
+          style={{
+            ...styles.inputWrap,
+            ...(focusedField === 'email' ? styles.inputWrapFocused : {}),
+          }}
+        >
+          <span style={styles.inputIcon}>✉</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onFocus={() => setFocusedField('email')}
+            onBlur={() => setFocusedField(null)}
+            required
+            style={styles.input}
+            placeholder="banana@example.com"
+          />
+        </div>
+      </div>
+
+      <div style={styles.fieldGroup}>
+        <label style={styles.label}>パスワード</label>
+        <div
+          style={{
+            ...styles.inputWrap,
+            ...(focusedField === 'password' ? styles.inputWrapFocused : {}),
+          }}
+        >
+          <span style={styles.inputIcon}>🔒</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onFocus={() => setFocusedField('password')}
+            onBlur={() => setFocusedField(null)}
+            required
+            style={styles.input}
+            placeholder="••••••••"
+          />
+        </div>
+      </div>
+
+      <button type="submit" disabled={isSubmitting} style={styles.button}>
+        <span style={styles.buttonText}>
+          {isSubmitting ? 'ログイン中...' : 'ログイン'}
+        </span>
+        {!isSubmitting && <span style={styles.buttonIcon}>→</span>}
+      </button>
+
+      <div style={styles.divider}>
+        <span style={styles.dividerLine} />
+        <span style={styles.dividerText}>or</span>
+        <span style={styles.dividerLine} />
+      </div>
+
+      <p style={styles.switchText}>
+        はじめての方は{' '}
+        <button
+          type="button"
+          onClick={onSwitchToSignup}
+          style={styles.linkButton}
+        >
+          アカウント作成
+        </button>
+      </p>
+    </form>
+  );
+}
+
+const styles = {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    width: '100%',
+  },
+  fieldGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  label: {
+    fontSize: '12px',
+    fontWeight: 700,
+    color: '#8a7a60',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    paddingLeft: '2px',
+  },
+  inputWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '0 14px',
+    borderRadius: '12px',
+    border: '1.5px solid rgba(212, 175, 55, 0.15)',
+    background: 'rgba(255, 253, 240, 0.6)',
+    transition: 'all 0.25s ease',
+  },
+  inputWrapFocused: {
+    borderColor: 'rgba(212, 175, 55, 0.5)',
+    background: 'rgba(255, 253, 240, 0.9)',
+    boxShadow: '0 0 0 3px rgba(212, 175, 55, 0.1)',
+  },
+  inputIcon: {
+    fontSize: '14px',
+    opacity: 0.5,
+    flexShrink: 0,
+  },
+  input: {
+    flex: 1,
+    padding: '12px 0',
+    border: 'none',
+    background: 'transparent',
+    fontSize: '15px',
+    color: '#4a4a4a',
+    outline: 'none',
+    fontFamily: "'Outfit', sans-serif",
+  },
+  button: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '8px',
+    padding: '14px',
+    borderRadius: '14px',
+    border: 'none',
+    background:
+      'linear-gradient(135deg, #d4af37 0%, #e8c84a 50%, #b8860b 100%)',
+    backgroundSize: '200% 200%',
+    color: '#fff',
+    fontSize: '16px',
+    fontWeight: 700,
+    fontFamily: "'Outfit', sans-serif",
+    cursor: 'pointer',
+    marginTop: '4px',
+    transition: 'all 0.3s ease',
+    boxShadow: '0 4px 16px rgba(212, 175, 55, 0.35)',
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  buttonText: {
+    position: 'relative',
+    zIndex: 1,
+  },
+  buttonIcon: {
+    fontSize: '18px',
+    position: 'relative',
+    zIndex: 1,
+    transition: 'transform 0.2s ease',
+  },
+  divider: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    margin: '4px 0',
+  },
+  dividerLine: {
+    flex: 1,
+    height: '1px',
+    background:
+      'linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.2), transparent)',
+  },
+  dividerText: {
+    fontSize: '11px',
+    color: '#bba880',
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.1em',
+  },
+  switchText: {
+    margin: 0,
+    textAlign: 'center',
+    fontSize: '13px',
+    color: '#8a7a60',
+  },
+  linkButton: {
+    background: 'none',
+    border: 'none',
+    color: '#b8860b',
+    fontWeight: 700,
+    cursor: 'pointer',
+    padding: 0,
+    fontSize: '13px',
+    fontFamily: "'Outfit', sans-serif",
+    textDecoration: 'none',
+    borderBottom: '1.5px solid rgba(184, 134, 11, 0.3)',
+    transition: 'border-color 0.2s',
+  },
+  error: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    margin: 0,
+    padding: '10px 14px',
+    borderRadius: '10px',
+    background: 'rgba(220, 38, 38, 0.06)',
+    border: '1px solid rgba(220, 38, 38, 0.12)',
+    color: '#b91c1c',
+    fontSize: '13px',
+    lineHeight: 1.4,
+  },
+  errorIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '18px',
+    height: '18px',
+    borderRadius: '50%',
+    background: '#dc2626',
+    color: '#fff',
+    fontSize: '11px',
+    fontWeight: 800,
+    flexShrink: 0,
+  },
+};

--- a/src/components/auth/SignupForm.jsx
+++ b/src/components/auth/SignupForm.jsx
@@ -44,14 +44,16 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
   return (
     <form onSubmit={handleSubmit} style={styles.form}>
       {displayError && (
-        <div style={styles.error}>
+        <div role="alert" style={styles.error}>
           <span style={styles.errorIcon}>!</span>
           {displayError}
         </div>
       )}
 
       <div style={styles.fieldGroup}>
-        <label style={styles.label}>メールアドレス</label>
+        <label htmlFor="signup-email" style={styles.label}>
+          メールアドレス
+        </label>
         <div
           style={{
             ...styles.inputWrap,
@@ -60,12 +62,14 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
         >
           <span style={styles.inputIcon}>✉</span>
           <input
+            id="signup-email"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             onFocus={() => setFocusedField('email')}
             onBlur={() => setFocusedField(null)}
             required
+            autoComplete="email"
             style={styles.input}
             placeholder="banana@example.com"
           />
@@ -73,7 +77,9 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
       </div>
 
       <div style={styles.fieldGroup}>
-        <label style={styles.label}>パスワード</label>
+        <label htmlFor="signup-password" style={styles.label}>
+          パスワード
+        </label>
         <div
           style={{
             ...styles.inputWrap,
@@ -82,13 +88,18 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
         >
           <span style={styles.inputIcon}>🔒</span>
           <input
+            id="signup-password"
             type="password"
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              if (localError) setLocalError('');
+            }}
             onFocus={() => setFocusedField('password')}
             onBlur={() => setFocusedField(null)}
             required
             minLength={8}
+            autoComplete="new-password"
             style={styles.input}
             placeholder="8文字以上"
           />
@@ -122,7 +133,9 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
       </div>
 
       <div style={styles.fieldGroup}>
-        <label style={styles.label}>パスワード（確認）</label>
+        <label htmlFor="signup-confirm-password" style={styles.label}>
+          パスワード（確認）
+        </label>
         <div
           style={{
             ...styles.inputWrap,
@@ -131,9 +144,13 @@ export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
         >
           <span style={styles.inputIcon}>🔒</span>
           <input
+            id="signup-confirm-password"
             type="password"
             value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value);
+              if (localError) setLocalError('');
+            }}
             onFocus={() => setFocusedField('confirm')}
             onBlur={() => setFocusedField(null)}
             required

--- a/src/components/auth/SignupForm.jsx
+++ b/src/components/auth/SignupForm.jsx
@@ -1,0 +1,297 @@
+import { useState } from 'react';
+
+export default function SignupForm({ onSubmit, onSwitchToLogin, error }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [localError, setLocalError] = useState('');
+  const [focusedField, setFocusedField] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLocalError('');
+
+    if (password !== confirmPassword) {
+      setLocalError('パスワードが一致しません');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(email, password);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const displayError = localError || error;
+
+  const passwordStrength =
+    password.length === 0
+      ? 0
+      : password.length < 8
+        ? 1
+        : /[A-Z]/.test(password) &&
+            /[0-9]/.test(password) &&
+            /[^A-Za-z0-9]/.test(password)
+          ? 3
+          : 2;
+
+  const strengthColors = ['transparent', '#e57373', '#ffb74d', '#81c784'];
+  const strengthLabels = ['', '弱い', '普通', '強い'];
+
+  return (
+    <form onSubmit={handleSubmit} style={styles.form}>
+      {displayError && (
+        <div style={styles.error}>
+          <span style={styles.errorIcon}>!</span>
+          {displayError}
+        </div>
+      )}
+
+      <div style={styles.fieldGroup}>
+        <label style={styles.label}>メールアドレス</label>
+        <div
+          style={{
+            ...styles.inputWrap,
+            ...(focusedField === 'email' ? styles.inputWrapFocused : {}),
+          }}
+        >
+          <span style={styles.inputIcon}>✉</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onFocus={() => setFocusedField('email')}
+            onBlur={() => setFocusedField(null)}
+            required
+            style={styles.input}
+            placeholder="banana@example.com"
+          />
+        </div>
+      </div>
+
+      <div style={styles.fieldGroup}>
+        <label style={styles.label}>パスワード</label>
+        <div
+          style={{
+            ...styles.inputWrap,
+            ...(focusedField === 'password' ? styles.inputWrapFocused : {}),
+          }}
+        >
+          <span style={styles.inputIcon}>🔒</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onFocus={() => setFocusedField('password')}
+            onBlur={() => setFocusedField(null)}
+            required
+            minLength={8}
+            style={styles.input}
+            placeholder="8文字以上"
+          />
+        </div>
+        {password.length > 0 && (
+          <div style={styles.strengthRow}>
+            <div style={styles.strengthBar}>
+              {[1, 2, 3].map((level) => (
+                <div
+                  key={level}
+                  style={{
+                    ...styles.strengthSegment,
+                    background:
+                      passwordStrength >= level
+                        ? strengthColors[passwordStrength]
+                        : 'rgba(0,0,0,0.06)',
+                  }}
+                />
+              ))}
+            </div>
+            <span
+              style={{
+                ...styles.strengthLabel,
+                color: strengthColors[passwordStrength],
+              }}
+            >
+              {strengthLabels[passwordStrength]}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div style={styles.fieldGroup}>
+        <label style={styles.label}>パスワード（確認）</label>
+        <div
+          style={{
+            ...styles.inputWrap,
+            ...(focusedField === 'confirm' ? styles.inputWrapFocused : {}),
+          }}
+        >
+          <span style={styles.inputIcon}>🔒</span>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            onFocus={() => setFocusedField('confirm')}
+            onBlur={() => setFocusedField(null)}
+            required
+            style={styles.input}
+            placeholder="もう一度入力"
+          />
+        </div>
+      </div>
+
+      <button type="submit" disabled={isSubmitting} style={styles.button}>
+        {isSubmitting ? 'アカウント作成中...' : 'アカウントを作成'}
+      </button>
+
+      <p style={styles.switchText}>
+        すでにアカウントをお持ちの方は{' '}
+        <button
+          type="button"
+          onClick={onSwitchToLogin}
+          style={styles.linkButton}
+        >
+          ログイン
+        </button>
+      </p>
+    </form>
+  );
+}
+
+const styles = {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '14px',
+    width: '100%',
+  },
+  fieldGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  label: {
+    fontSize: '12px',
+    fontWeight: 700,
+    color: '#8a7a60',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    paddingLeft: '2px',
+  },
+  inputWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '0 14px',
+    borderRadius: '12px',
+    border: '1.5px solid rgba(212, 175, 55, 0.15)',
+    background: 'rgba(255, 253, 240, 0.6)',
+    transition: 'all 0.25s ease',
+  },
+  inputWrapFocused: {
+    borderColor: 'rgba(212, 175, 55, 0.5)',
+    background: 'rgba(255, 253, 240, 0.9)',
+    boxShadow: '0 0 0 3px rgba(212, 175, 55, 0.1)',
+  },
+  inputIcon: {
+    fontSize: '14px',
+    opacity: 0.5,
+    flexShrink: 0,
+  },
+  input: {
+    flex: 1,
+    padding: '12px 0',
+    border: 'none',
+    background: 'transparent',
+    fontSize: '15px',
+    color: '#4a4a4a',
+    outline: 'none',
+    fontFamily: "'Outfit', sans-serif",
+  },
+  strengthRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    paddingLeft: '2px',
+  },
+  strengthBar: {
+    display: 'flex',
+    gap: '3px',
+    flex: 1,
+  },
+  strengthSegment: {
+    height: '3px',
+    flex: 1,
+    borderRadius: '2px',
+    transition: 'background 0.3s ease',
+  },
+  strengthLabel: {
+    fontSize: '11px',
+    fontWeight: 700,
+    minWidth: '28px',
+    textAlign: 'right',
+    transition: 'color 0.3s ease',
+  },
+  button: {
+    padding: '14px',
+    borderRadius: '14px',
+    border: 'none',
+    background:
+      'linear-gradient(135deg, #d4af37 0%, #e8c84a 50%, #b8860b 100%)',
+    color: '#fff',
+    fontSize: '16px',
+    fontWeight: 700,
+    fontFamily: "'Outfit', sans-serif",
+    cursor: 'pointer',
+    marginTop: '4px',
+    transition: 'all 0.3s ease',
+    boxShadow: '0 4px 16px rgba(212, 175, 55, 0.35)',
+  },
+  switchText: {
+    margin: 0,
+    textAlign: 'center',
+    fontSize: '13px',
+    color: '#8a7a60',
+  },
+  linkButton: {
+    background: 'none',
+    border: 'none',
+    color: '#b8860b',
+    fontWeight: 700,
+    cursor: 'pointer',
+    padding: 0,
+    fontSize: '13px',
+    fontFamily: "'Outfit', sans-serif",
+    borderBottom: '1.5px solid rgba(184, 134, 11, 0.3)',
+    transition: 'border-color 0.2s',
+  },
+  error: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    margin: 0,
+    padding: '10px 14px',
+    borderRadius: '10px',
+    background: 'rgba(220, 38, 38, 0.06)',
+    border: '1px solid rgba(220, 38, 38, 0.12)',
+    color: '#b91c1c',
+    fontSize: '13px',
+    lineHeight: 1.4,
+  },
+  errorIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '18px',
+    height: '18px',
+    borderRadius: '50%',
+    background: '#dc2626',
+    color: '#fff',
+    fontSize: '11px',
+    fontWeight: 800,
+    flexShrink: 0,
+  },
+};

--- a/src/components/ui/BananaTree.jsx
+++ b/src/components/ui/BananaTree.jsx
@@ -129,7 +129,9 @@ export default function BananaTree({
   }, [treeLevel]);
 
   return (
-    <div
+    <section
+      className="banana-tree-panel"
+      aria-label={`バナナツリー レベル${treeLevel} - ${currentStage.label}`}
       style={{
         position: 'fixed',
         top: 130,
@@ -144,7 +146,7 @@ export default function BananaTree({
     >
       {/* ── メインパネル ── */}
       <div
-        className="glass-panel"
+        className="glass-panel banana-tree-main"
         style={{
           padding: '14px 16px',
           display: 'flex',
@@ -173,9 +175,10 @@ export default function BananaTree({
           }}
         >
           <img
+            className="tree-image"
             key={stageIndex}
             src={imgSrc}
-            alt={currentStage.label}
+            alt={`${currentStage.label} ステージのバナナツリー`}
             style={{
               width: 140,
               height: 140,
@@ -189,6 +192,7 @@ export default function BananaTree({
           {/* Stage name + LV badge */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <span
+              className="tree-stage-label"
               style={{
                 fontSize: '0.78rem',
                 fontWeight: 900,
@@ -199,6 +203,7 @@ export default function BananaTree({
               {currentStage.label}
             </span>
             <div
+              className="tree-lv-badge"
               style={{
                 fontSize: '0.58rem',
                 fontWeight: 900,
@@ -247,6 +252,11 @@ export default function BananaTree({
 
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <div
+                role="progressbar"
+                aria-valuenow={Math.round(progress)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label="バナコインまでの進捗"
                 style={{
                   flex: 1,
                   height: 7,
@@ -293,6 +303,8 @@ export default function BananaTree({
             }}
           >
             <button
+              className="water-button"
+              aria-label={`水やり +${waterBoostPercent}%、コスト: ${cost.toLocaleString()} バナナ`}
               onClick={() => canAfford && onWater()}
               disabled={!canAfford}
               style={{
@@ -493,7 +505,9 @@ export default function BananaTree({
       {/* ── スキル選択パネル（ツリーパネルの直下） ── */}
       {pendingChoice && (
         <div
-          className="glass-panel"
+          className="glass-panel skill-choose-panel"
+          role="dialog"
+          aria-label="スキル選択"
           style={{
             width: 192,
             display: 'flex',
@@ -627,6 +641,6 @@ export default function BananaTree({
           </div>
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/components/ui/ScoreDisplay.jsx
+++ b/src/components/ui/ScoreDisplay.jsx
@@ -1,71 +1,33 @@
+import styles from './ScoreDisplay.module.css';
+
 function ScoreDisplay({ score, perSecond, scoreBump, devMode }) {
+  const animClass = scoreBump
+    ? styles.bump
+    : perSecond > 0
+      ? styles.breathing
+      : '';
+
   return (
     <div
-      className="glass-panel"
-      style={{
-        position: 'fixed',
-        top: 24,
-        left: 24,
-        zIndex: 10,
-        padding: '16px 24px',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        gap: 0,
-        userSelect: 'none',
-        animation: scoreBump
-          ? 'scoreBump 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28)'
-          : perSecond > 0
-            ? 'breathingGold 3s ease-in-out infinite'
-            : 'none',
-        transition: 'all 0.3s ease',
-      }}
+      className={`glass-panel score-display ${styles.root} ${animClass}`}
+      role="status"
+      aria-label={`スコア: ${score.toLocaleString()}、毎秒 ${perSecond.toLocaleString()} ポイント`}
+      aria-live="polite"
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ fontSize: '1.2rem', color: 'var(--accent-gold)' }}>
+      <div className={styles.row}>
+        <span className={styles.icon} aria-hidden="true">
           🍌
         </span>
-        <span
-          style={{
-            fontSize: '1.4rem',
-            fontWeight: 800,
-            letterSpacing: '-0.02em',
-            color: 'var(--text-main)',
-          }}
-        >
+        <span className={`score-value ${styles.value}`}>
           {score.toLocaleString()}
         </span>
-        {devMode && (
-          <span
-            style={{
-              fontSize: '0.6rem',
-              background: 'var(--accent-gold)',
-              color: '#fff',
-              borderRadius: 4,
-              padding: '2px 6px',
-              fontWeight: 700,
-              letterSpacing: '0.05em',
-            }}
-          >
-            STUDIO
-          </span>
-        )}
+        {devMode && <span className={styles.studioBadge}>STUDIO</span>}
       </div>
-      <div
-        style={{
-          paddingLeft: 22,
-          fontSize: '0.75rem',
-          fontWeight: 500,
-          color: 'var(--text-muted)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 4,
-        }}
-      >
-        <span style={{ color: 'var(--accent-gold)', fontWeight: 600 }}>
+      <div className={styles.perSecondRow}>
+        <span className={styles.perSecondValue}>
           +{perSecond.toLocaleString()}
         </span>
-        <span style={{ fontSize: '0.65rem' }}>/秒</span>
+        <span className={`per-second-label ${styles.perSecondLabel}`}>/秒</span>
       </div>
     </div>
   );

--- a/src/components/ui/ScoreDisplay.module.css
+++ b/src/components/ui/ScoreDisplay.module.css
@@ -1,0 +1,87 @@
+.root {
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  z-index: 10;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
+  user-select: none;
+  transition: all 0.3s ease;
+}
+
+.bump {
+  animation: scoreBump 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+}
+
+.breathing {
+  animation: breathingGold 3s ease-in-out infinite;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon {
+  font-size: 1.2rem;
+  color: var(--accent-gold);
+}
+
+.value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text-main);
+}
+
+.studioBadge {
+  font-size: 0.6rem;
+  background: var(--accent-gold);
+  color: #fff;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.perSecondRow {
+  padding-left: 22px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.perSecondValue {
+  color: var(--accent-gold);
+  font-weight: 600;
+}
+
+.perSecondLabel {
+  font-size: 0.65rem;
+}
+
+/* ── Responsive: small screens ── */
+@media (max-width: 768px) {
+  .root {
+    top: 12px;
+    left: 12px;
+    padding: 10px 14px;
+  }
+
+  .value {
+    font-size: 1.1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .perSecondLabel {
+    font-size: 0.55rem;
+  }
+}

--- a/src/components/ui/ShopButton.jsx
+++ b/src/components/ui/ShopButton.jsx
@@ -4,6 +4,7 @@ import styles from './ShopButton.module.css';
 export default function ShopButton({ banaCoins, onOpen }) {
   return (
     <button
+      type="button"
       className={`glass-panel shop-button ${styles.root}`}
       aria-label={`ショップを開く。バナコイン残高: ${banaCoins}`}
       onClick={onOpen}

--- a/src/components/ui/ShopButton.jsx
+++ b/src/components/ui/ShopButton.jsx
@@ -1,115 +1,32 @@
 import { Store } from 'lucide-react';
+import styles from './ShopButton.module.css';
 
 export default function ShopButton({ banaCoins, onOpen }) {
   return (
-    <div
-      className="glass-panel"
-      style={{
-        position: 'fixed',
-        top: 24,
-        right: 24,
-        zIndex: 10,
-        padding: '12px 18px',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        cursor: 'pointer',
-        transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-        background: 'rgba(255, 255, 255, 0.85)',
-        border: '1px solid var(--accent-gold-soft)',
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.transform = 'scale(1.05) translateY(-2px)';
-        e.currentTarget.style.borderColor = 'var(--accent-gold)';
-        e.currentTarget.style.boxShadow = '0 12px 24px rgba(212, 175, 55, 0.2)';
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.transform = 'scale(1) translateY(0)';
-        e.currentTarget.style.borderColor = 'var(--accent-gold-soft)';
-        e.currentTarget.style.boxShadow = 'var(--shadow-soft)';
-      }}
+    <button
+      className={`glass-panel shop-button ${styles.root}`}
+      aria-label={`ショップを開く。バナコイン残高: ${banaCoins}`}
       onClick={onOpen}
     >
-      {/* コインアイコン（大） */}
       <img
+        className={`shop-coin-icon ${styles.coinIcon}`}
         src={`${import.meta.env.BASE_URL}coin.png`}
-        alt="バナコイン"
-        style={{
-          width: 40,
-          height: 40,
-          objectFit: 'contain',
-          filter: 'drop-shadow(0 2px 6px rgba(212,175,55,0.5))',
-          flexShrink: 0,
-        }}
+        alt=""
       />
 
-      {/* バナコイン残高 */}
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          gap: 1,
-        }}
-      >
-        <span
-          style={{
-            fontSize: '0.6rem',
-            fontWeight: 700,
-            color: 'var(--text-muted)',
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-          }}
-        >
-          バナコイン
-        </span>
-        <span
-          style={{
-            fontSize: '1.3rem',
-            fontWeight: 900,
-            color: 'var(--accent-gold)',
-            letterSpacing: '-0.02em',
-            lineHeight: 1,
-            fontVariantNumeric: 'tabular-nums',
-          }}
-        >
+      <div className={styles.balanceColumn}>
+        <span className={styles.balanceLabel}>バナコイン</span>
+        <span className={`shop-coin-balance ${styles.balanceValue}`}>
           {banaCoins.toLocaleString()}
         </span>
       </div>
 
-      {/* 区切り */}
-      <div
-        style={{
-          width: 1,
-          height: 32,
-          background: 'rgba(0,0,0,0.08)',
-          flexShrink: 0,
-        }}
-      />
+      <div className={`shop-divider ${styles.divider}`} aria-hidden="true" />
 
-      {/* ショップアイコン */}
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 2,
-          color: 'var(--text-muted)',
-          flexShrink: 0,
-        }}
-      >
+      <div className={`shop-label ${styles.shopIcon}`} aria-hidden="true">
         <Store size={18} strokeWidth={2} />
-        <span
-          style={{
-            fontSize: '0.55rem',
-            fontWeight: 700,
-            letterSpacing: '0.06em',
-            textTransform: 'uppercase',
-          }}
-        >
-          Shop
-        </span>
+        <span className={styles.shopIconLabel}>Shop</span>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/components/ui/ShopButton.jsx
+++ b/src/components/ui/ShopButton.jsx
@@ -11,7 +11,7 @@ export default function ShopButton({ banaCoins, onOpen }) {
       <img
         className={`shop-coin-icon ${styles.coinIcon}`}
         src={`${import.meta.env.BASE_URL}coin.png`}
-        alt=""
+        alt="バナコイン"
       />
 
       <div className={styles.balanceColumn}>

--- a/src/components/ui/ShopButton.module.css
+++ b/src/components/ui/ShopButton.module.css
@@ -1,0 +1,101 @@
+.root {
+  position: fixed;
+  top: 38px;
+  right: 24px;
+  z-index: 10;
+  padding: 12px 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid var(--accent-gold-soft);
+  font-family: inherit;
+}
+
+.root:hover {
+  transform: scale(1.05) translateY(-2px);
+  border-color: var(--accent-gold);
+  box-shadow: 0 12px 24px rgba(212, 175, 55, 0.2);
+}
+
+.coinIcon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 6px rgba(212, 175, 55, 0.5));
+  flex-shrink: 0;
+}
+
+.balanceColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+}
+
+.balanceLabel {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.balanceValue {
+  font-size: 1.3rem;
+  font-weight: 900;
+  color: var(--accent-gold);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.divider {
+  width: 1px;
+  height: 32px;
+  background: rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
+}
+
+.shopIcon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.shopIconLabel {
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* ── Responsive: small screens ── */
+@media (max-width: 768px) {
+  .root {
+    top: 12px;
+    right: 12px;
+    padding: 8px 12px;
+  }
+
+  .coinIcon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .balanceValue {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .shopIcon,
+  .divider {
+    display: none;
+  }
+}

--- a/src/components/ui/ShopModal.jsx
+++ b/src/components/ui/ShopModal.jsx
@@ -24,6 +24,9 @@ export default function ShopModal({
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="ショップ"
       style={{
         position: 'fixed',
         inset: 0,
@@ -74,6 +77,7 @@ export default function ShopModal({
             🛒 SHOP
           </div>
           <button
+            aria-label="ショップを閉じる"
             onClick={onClose}
             style={{
               width: 36,

--- a/src/components/ui/UnlockedBananaTiers.jsx
+++ b/src/components/ui/UnlockedBananaTiers.jsx
@@ -32,7 +32,7 @@ function UnlockedBananaTiers({
     onekindBananaCount > 0;
 
   return (
-    <nav
+    <aside
       className="banana-ui-block unlocked-tiers-panel"
       aria-label="解放済みバナナ一覧"
       style={{
@@ -291,7 +291,7 @@ function UnlockedBananaTiers({
           </div>
         ))}
       </div>
-    </nav>
+    </aside>
   );
 }
 

--- a/src/components/ui/UnlockedBananaTiers.jsx
+++ b/src/components/ui/UnlockedBananaTiers.jsx
@@ -1,5 +1,6 @@
 const SectionLabel = ({ children }) => (
   <div
+    className="section-label"
     style={{
       fontSize: '0.6rem',
       fontWeight: 800,
@@ -31,18 +32,19 @@ function UnlockedBananaTiers({
     onekindBananaCount > 0;
 
   return (
-    <div
-      className="banana-ui-block"
+    <nav
+      className="banana-ui-block unlocked-tiers-panel"
+      aria-label="解放済みバナナ一覧"
       style={{
         position: 'fixed',
-        top: 110,
+        top: 130,
         right: 24,
         zIndex: 10,
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'flex-start',
         gap: 12,
-        maxHeight: 'calc(100vh - 110px - 120px)',
+        maxHeight: 'calc(100vh - 120px - 120px)',
       }}
     >
       {/* 特殊アイテムセクション（1体以上購入済みの場合のみ） */}
@@ -58,7 +60,7 @@ function UnlockedBananaTiers({
           <SectionLabel>Special</SectionLabel>
           {nuiBananaCount > 0 && (
             <div
-              className="glass-panel"
+              className="glass-panel tier-card"
               style={{
                 padding: '6px 14px',
                 fontSize: '0.75rem',
@@ -79,8 +81,9 @@ function UnlockedBananaTiers({
               }}
             >
               <img
+                className="tier-icon"
                 src={`${import.meta.env.BASE_URL}banana_nui.png`}
-                alt="ぬいバナナ"
+                alt=""
                 style={{ width: 24, height: 24, objectFit: 'contain' }}
               />
               <span>ぬいバナナ</span>
@@ -100,7 +103,7 @@ function UnlockedBananaTiers({
           )}
           {magicBananaCount > 0 && (
             <div
-              className="glass-panel"
+              className="glass-panel tier-card"
               style={{
                 padding: '6px 14px',
                 fontSize: '0.75rem',
@@ -121,8 +124,9 @@ function UnlockedBananaTiers({
               }}
             >
               <img
+                className="tier-icon"
                 src={`${import.meta.env.BASE_URL}banana_magic.png`}
-                alt="マジックバナナ"
+                alt=""
                 style={{ width: 24, height: 24, objectFit: 'contain' }}
               />
               <span>マジックバナナ</span>
@@ -142,7 +146,7 @@ function UnlockedBananaTiers({
           )}
           {blackholeBananaCount > 0 && (
             <div
-              className="glass-panel"
+              className="glass-panel tier-card"
               style={{
                 padding: '6px 14px',
                 fontSize: '0.75rem',
@@ -159,8 +163,9 @@ function UnlockedBananaTiers({
               }}
             >
               <img
+                className="tier-icon"
                 src={`${import.meta.env.BASE_URL}banana_blackhole.png`}
-                alt="ブラックホールバナナ"
+                alt=""
                 style={{ width: 24, height: 24, objectFit: 'contain' }}
               />
               <span>ブラックホール</span>
@@ -180,7 +185,7 @@ function UnlockedBananaTiers({
           )}
           {onekindBananaCount > 0 && (
             <div
-              className="glass-panel"
+              className="glass-panel tier-card"
               style={{
                 padding: '6px 14px',
                 fontSize: '0.75rem',
@@ -201,8 +206,9 @@ function UnlockedBananaTiers({
               }}
             >
               <img
+                className="tier-icon"
                 src={`${import.meta.env.BASE_URL}banana_onekind.png`}
-                alt="oneバナナ"
+                alt=""
                 style={{ width: 24, height: 24, objectFit: 'contain' }}
               />
               <span>oneバナナ</span>
@@ -238,7 +244,7 @@ function UnlockedBananaTiers({
         {unlockedTiers.map((tier) => (
           <div
             key={tier.tier}
-            className="glass-panel"
+            className="glass-panel tier-card"
             style={{
               padding: '6px 14px',
               fontSize: '0.75rem',
@@ -263,12 +269,14 @@ function UnlockedBananaTiers({
             }}
           >
             <img
+              className="tier-icon"
               src={`${import.meta.env.BASE_URL}${tier.icon}`}
-              alt={tier.name}
+              alt=""
               style={{ width: 24, height: 24, objectFit: 'contain' }}
             />
             <span>{tier.name}</span>
             <span
+              className="tier-score"
               style={{
                 fontSize: '0.65rem',
                 opacity: 0.6,
@@ -283,7 +291,7 @@ function UnlockedBananaTiers({
           </div>
         ))}
       </div>
-    </div>
+    </nav>
   );
 }
 

--- a/src/components/ui/UpgradeGroupCard.jsx
+++ b/src/components/ui/UpgradeGroupCard.jsx
@@ -1,3 +1,5 @@
+import styles from './UpgradeGroupCard.module.css';
+
 function UpgradeGroupCard({
   group,
   currentLabel,
@@ -18,17 +20,30 @@ function UpgradeGroupCard({
   const name = spaceIdx >= 0 ? group.label.slice(spaceIdx + 1) : '';
 
   return (
-    <div
-      style={{
-        flex: 1,
-        minWidth: 0,
-      }}
-    >
+    <div className={styles.wrapper}>
       <div
+        className={styles.card}
+        role={nextItem && affordable ? 'button' : undefined}
+        tabIndex={nextItem && affordable ? 0 : undefined}
+        aria-label={
+          isMaxed
+            ? `${group.label} - 最大レベル`
+            : nextItem
+              ? `${group.label} Lv.${level} → ${nextItem.label}、コスト: ${nextItem.cost.toLocaleString()}`
+              : undefined
+        }
+        onKeyDown={
+          nextItem && affordable
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onBuy(nextItem);
+                }
+              }
+            : undefined
+        }
         style={{
-          position: 'relative',
-          overflow: 'hidden',
-          borderRadius: 12,
           border: `1.5px solid ${
             isMaxed
               ? 'var(--status-maxed-border)'
@@ -46,8 +61,6 @@ function UpgradeGroupCard({
               ? '0 2px 12px rgba(212,175,55,0.22)'
               : '0 1px 4px rgba(0,0,0,0.06)',
           cursor: nextItem && affordable ? 'pointer' : 'default',
-          transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-          userSelect: 'none',
           animation:
             affordable && !isMaxed
               ? 'upgradeGlow 2.4s ease-in-out infinite'
@@ -81,32 +94,12 @@ function UpgradeGroupCard({
           e.currentTarget.style.transform = 'translateY(-2px)';
         }}
       >
-        {/* Shimmer overlay when affordable */}
-        {affordable && !isMaxed && (
-          <div
-            style={{
-              position: 'absolute',
-              top: '-50%',
-              left: '-50%',
-              width: '200%',
-              height: '200%',
-              background:
-                'linear-gradient(45deg, transparent 0%, rgba(255,255,255,0.45) 50%, transparent 100%)',
-              transform: 'rotate(45deg)',
-              animation: 'shimmer 3s infinite',
-              pointerEvents: 'none',
-              zIndex: 1,
-            }}
-          />
-        )}
+        {affordable && !isMaxed && <div className={styles.shimmer} />}
 
-        {/* Header: icon + name + level badge */}
+        {/* Header */}
         <div
+          className={styles.header}
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '5px 7px 4px',
             borderBottom: `1px solid ${
               isMaxed
                 ? 'var(--status-maxed-bg)'
@@ -114,29 +107,22 @@ function UpgradeGroupCard({
                   ? 'rgba(212,175,55,0.18)'
                   : 'rgba(0,0,0,0.05)'
             }`,
-            position: 'relative',
-            zIndex: 2,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-            <span style={{ fontSize: '0.85rem', lineHeight: 1 }}>{icon}</span>
+          <div className={styles.headerLeft}>
+            <span className={styles.headerIcon}>{icon}</span>
             <span
+              className={`upgrade-card-header-name ${styles.headerName}`}
               style={{
-                fontSize: '0.58rem',
-                fontWeight: 700,
                 color: isMaxed ? 'var(--status-maxed)' : 'var(--text-muted)',
-                letterSpacing: '0.03em',
-                whiteSpace: 'nowrap',
               }}
             >
               {name}
             </span>
           </div>
-          {/* Level badge */}
           <div
+            className={styles.levelBadge}
             style={{
-              fontSize: '0.52rem',
-              fontWeight: 800,
               color: isMaxed
                 ? '#4caf50'
                 : affordable
@@ -147,10 +133,6 @@ function UpgradeGroupCard({
                 : affordable
                   ? 'rgba(212,175,55,0.14)'
                   : 'rgba(0,0,0,0.05)',
-              borderRadius: 5,
-              padding: '1px 5px',
-              letterSpacing: '0.02em',
-              whiteSpace: 'nowrap',
             }}
           >
             Lv.{level}
@@ -159,116 +141,35 @@ function UpgradeGroupCard({
 
         {/* Body */}
         {isMaxed ? (
-          /* ── MAXED ── */
-          <div
-            style={{
-              padding: '8px 6px 9px',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: 2,
-              position: 'relative',
-              zIndex: 2,
-            }}
-          >
-            <span style={{ fontSize: '1rem', lineHeight: 1 }}>✅</span>
-            <div
-              style={{
-                fontSize: '0.65rem',
-                fontWeight: 800,
-                color: 'var(--status-maxed)',
-                letterSpacing: '0.08em',
-              }}
-            >
-              MAXED
-            </div>
-            <div
-              style={{
-                fontSize: '0.6rem',
-                fontWeight: 600,
-                color: 'var(--text-muted)',
-                maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                textAlign: 'center',
-              }}
-            >
-              {currentLabel}
-            </div>
+          <div className={styles.bodyMaxed}>
+            <span className={styles.maxedIcon}>✅</span>
+            <div className={styles.maxedLabel}>MAXED</div>
+            <div className={styles.maxedDescription}>{currentLabel}</div>
           </div>
         ) : (
-          /* ── Normal ── */
-          <div
-            style={{
-              padding: '6px 8px 14px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 3,
-              alignItems: 'center',
-              position: 'relative',
-              zIndex: 2,
-            }}
-          >
-            {/* Current state */}
-            <div
-              style={{
-                fontSize: '0.59rem',
-                fontWeight: 600,
-                color: 'var(--text-muted)',
-                maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                lineHeight: 1.3,
-                textAlign: 'center',
-              }}
-            >
+          <div className={styles.bodyNormal}>
+            <div className={`upgrade-card-body-label ${styles.currentLabel}`}>
               {currentLabel}
             </div>
-
-            {/* Next upgrade name */}
-            <div
-              style={{
-                fontSize: '0.78rem',
-                fontWeight: 800,
-                color: 'var(--text-main)',
-                maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                letterSpacing: '-0.01em',
-                lineHeight: 1.2,
-                textAlign: 'center',
-              }}
-            >
+            <div className={`upgrade-card-body-next ${styles.nextLabel}`}>
               {nextItem.label}
             </div>
-
-            {/* Cost pill */}
             <div
+              className={`upgrade-card-cost-pill ${styles.costPill}`}
               style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 3,
                 background: affordable
                   ? 'rgba(212,175,55,0.15)'
                   : 'rgba(0,0,0,0.05)',
                 border: `1px solid ${affordable ? 'rgba(212,175,55,0.3)' : 'transparent'}`,
-                borderRadius: 20,
-                padding: '2px 7px',
-                marginTop: 1,
               }}
             >
-              <span style={{ fontSize: '0.7em', lineHeight: 1 }}>🍌</span>
+              <span className={styles.costEmoji}>🍌</span>
               <span
+                className={styles.costValue}
                 style={{
-                  fontSize: '0.63rem',
-                  fontWeight: 700,
                   color: affordable
                     ? 'var(--accent-gold)'
                     : 'var(--text-muted)',
-                  fontVariantNumeric: 'tabular-nums',
                 }}
               >
                 {nextItem.cost.toLocaleString()}
@@ -280,14 +181,12 @@ function UpgradeGroupCard({
         {/* Progress bar */}
         {!isMaxed && (
           <div
-            style={{
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: 6,
-              background: 'var(--progress-bg)',
-            }}
+            className={styles.progressTrack}
+            role="progressbar"
+            aria-valuenow={Math.round(progress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${name} アップグレード進捗`}
           >
             <div
               style={{

--- a/src/components/ui/UpgradeGroupCard.jsx
+++ b/src/components/ui/UpgradeGroupCard.jsx
@@ -21,27 +21,15 @@ function UpgradeGroupCard({
 
   return (
     <div className={styles.wrapper}>
-      <div
+      <button
         className={styles.card}
-        role={nextItem && affordable ? 'button' : undefined}
-        tabIndex={nextItem && affordable ? 0 : undefined}
+        disabled={!nextItem || !affordable}
         aria-label={
           isMaxed
             ? `${group.label} - 最大レベル`
             : nextItem
               ? `${group.label} Lv.${level} → ${nextItem.label}、コスト: ${nextItem.cost.toLocaleString()}`
               : undefined
-        }
-        onKeyDown={
-          nextItem && affordable
-            ? (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onBuy(nextItem);
-                }
-              }
-            : undefined
         }
         style={{
           border: `1.5px solid ${
@@ -66,14 +54,10 @@ function UpgradeGroupCard({
               ? 'upgradeGlow 2.4s ease-in-out infinite'
               : 'none',
         }}
-        onClick={
-          nextItem && affordable
-            ? (e) => {
-                e.stopPropagation();
-                onBuy(nextItem);
-              }
-            : undefined
-        }
+        onClick={(e) => {
+          e.stopPropagation();
+          if (nextItem && affordable) onBuy(nextItem);
+        }}
         onMouseEnter={(e) => {
           if (!affordable || !nextItem) return;
           e.currentTarget.style.transform = 'translateY(-2px)';
@@ -205,7 +189,7 @@ function UpgradeGroupCard({
             />
           </div>
         )}
-      </div>
+      </button>
     </div>
   );
 }

--- a/src/components/ui/UpgradeGroupCard.module.css
+++ b/src/components/ui/UpgradeGroupCard.module.css
@@ -1,0 +1,198 @@
+.wrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  user-select: none;
+  /* button reset */
+  display: block;
+  width: 100%;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  background: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.card:disabled {
+  cursor: default;
+}
+
+.shimmer {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(
+    45deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.45) 50%,
+    transparent 100%
+  );
+  transform: rotate(45deg);
+  animation: shimmer 3s infinite;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 7px 4px;
+  position: relative;
+  z-index: 2;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.headerIcon {
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.headerName {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.levelBadge {
+  font-size: 0.52rem;
+  font-weight: 800;
+  border-radius: 5px;
+  padding: 1px 5px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.bodyMaxed {
+  padding: 8px 6px 9px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+  z-index: 2;
+}
+
+.maxedIcon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.maxedLabel {
+  font-size: 0.65rem;
+  font-weight: 800;
+  color: var(--status-maxed);
+  letter-spacing: 0.08em;
+}
+
+.maxedDescription {
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.bodyNormal {
+  padding: 6px 8px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  align-items: center;
+  position: relative;
+  z-index: 2;
+}
+
+.currentLabel {
+  font-size: 0.59rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.nextLabel {
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: var(--text-main);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.costPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border-radius: 20px;
+  padding: 2px 7px;
+  margin-top: 1px;
+}
+
+.costEmoji {
+  font-size: 0.7em;
+  line-height: 1;
+}
+
+.costValue {
+  font-size: 0.63rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.progressTrack {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  background: var(--progress-bg);
+}
+
+/* ── Responsive: small screens ── */
+@media (max-width: 768px) {
+  .headerName {
+    font-size: 0.5rem;
+  }
+
+  .currentLabel {
+    font-size: 0.52rem;
+  }
+
+  .nextLabel {
+    font-size: 0.68rem;
+  }
+
+  .costPill {
+    font-size: 0.56rem;
+  }
+}

--- a/src/components/ui/UpgradePanel.jsx
+++ b/src/components/ui/UpgradePanel.jsx
@@ -1,26 +1,12 @@
 import UpgradeGroupCard from './UpgradeGroupCard';
 import { buildGroupUpgradeViewModel } from '../../services/upgradeRules';
+import styles from './UpgradePanel.module.css';
 
 function UpgradePanel({ groups, purchased, score, onBuy, devMode }) {
   return (
-    <div
-      className="glass-panel"
-      style={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        zIndex: 10,
-        paddingTop: '6px',
-        paddingLeft: '12px',
-        paddingRight: '12px',
-        paddingBottom: 'calc(8px + env(safe-area-inset-bottom, 0px))',
-        display: 'flex',
-        gap: 8,
-        borderRadius: '16px 16px 0 0',
-        border: '1px solid rgba(255, 255, 255, 0.5)',
-        borderBottom: 'none',
-      }}
+    <nav
+      className={`glass-panel upgrade-panel ${styles.root}`}
+      aria-label="アップグレード"
     >
       {groups.map((group) => {
         const { currentLabel, nextItem, affordable, level, maxLevel } =
@@ -45,7 +31,7 @@ function UpgradePanel({ groups, purchased, score, onBuy, devMode }) {
           />
         );
       })}
-    </div>
+    </nav>
   );
 }
 

--- a/src/components/ui/UpgradePanel.jsx
+++ b/src/components/ui/UpgradePanel.jsx
@@ -4,7 +4,7 @@ import styles from './UpgradePanel.module.css';
 
 function UpgradePanel({ groups, purchased, score, onBuy, devMode }) {
   return (
-    <nav
+    <section
       className={`glass-panel upgrade-panel ${styles.root}`}
       aria-label="アップグレード"
     >
@@ -31,7 +31,7 @@ function UpgradePanel({ groups, purchased, score, onBuy, devMode }) {
           />
         );
       })}
-    </nav>
+    </section>
   );
 }
 

--- a/src/components/ui/UpgradePanel.module.css
+++ b/src/components/ui/UpgradePanel.module.css
@@ -1,0 +1,25 @@
+.root {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  padding-top: 6px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  gap: 8px;
+  border-radius: 16px 16px 0 0;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-bottom: none;
+}
+
+/* ── Responsive: small screens ── */
+@media (max-width: 768px) {
+  .root {
+    gap: 4px;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -5,14 +5,17 @@ import {
   signIn,
   signOut,
   getCurrentSession,
+  isCognitoConfigured,
 } from '../services/cognitoAuth';
 import { AuthContext } from './authContextValue';
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(isCognitoConfigured);
 
   useEffect(() => {
+    if (!isCognitoConfigured) return;
+
     getCurrentSession()
       .then((session) => {
         if (session) {
@@ -53,8 +56,9 @@ export function AuthProvider({ children }) {
     <AuthContext.Provider
       value={{
         user,
-        isAuthenticated: !!user,
+        isAuthenticated: !isCognitoConfigured || !!user,
         isLoading,
+        authEnabled: isCognitoConfigured,
         signUp: handleSignUp,
         confirmSignUp: handleConfirmSignUp,
         signIn: handleSignIn,

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react';
+import {
+  signUp,
+  confirmSignUp,
+  signIn,
+  signOut,
+  getCurrentSession,
+} from '../services/cognitoAuth';
+import { AuthContext } from './authContextValue';
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    getCurrentSession()
+      .then((session) => {
+        if (session) {
+          setUser({
+            email: session.getIdToken().payload.email,
+            sub: session.getIdToken().payload.sub,
+          });
+        }
+      })
+      .catch(() => {
+        // No valid session
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleSignUp = async (email, password) => {
+    await signUp(email, password);
+  };
+
+  const handleConfirmSignUp = async (email, code) => {
+    await confirmSignUp(email, code);
+  };
+
+  const handleSignIn = async (email, password) => {
+    const session = await signIn(email, password);
+    setUser({
+      email: session.getIdToken().payload.email,
+      sub: session.getIdToken().payload.sub,
+    });
+  };
+
+  const handleSignOut = () => {
+    signOut();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !!user,
+        isLoading,
+        signUp: handleSignUp,
+        confirmSignUp: handleConfirmSignUp,
+        signIn: handleSignIn,
+        signOut: handleSignOut,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/contexts/authContextValue.js
+++ b/src/contexts/authContextValue.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext(null);

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/authContextValue';
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -90,6 +90,81 @@ body {
   text-align: center;
 }
 
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Auth screen animations */
+@keyframes bananaFall {
+  0% {
+    transform: translateY(0) rotate(var(--r, 0deg));
+    opacity: 0;
+  }
+
+  5% {
+    opacity: 0.35;
+  }
+
+  90% {
+    opacity: 0.35;
+  }
+
+  100% {
+    transform: translateY(110vh) rotate(calc(var(--r, 0deg) + 180deg));
+    opacity: 0;
+  }
+}
+
+@keyframes bananaFloat {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-8deg);
+  }
+
+  50% {
+    transform: translateY(-8px) rotate(-4deg);
+  }
+}
+
+@keyframes loaderPulse {
+  0%,
+  100% {
+    transform: scaleX(1);
+    opacity: 0.3;
+  }
+
+  50% {
+    transform: scaleX(1.8);
+    opacity: 0.6;
+  }
+}
+
+@keyframes authSlideInRight {
+  from {
+    transform: translateX(20px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes authSlideInLeft {
+  from {
+    transform: translateX(-20px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
 /* Glassmorphism utility */
 .glass-panel {
   background: var(--glass-bg);

--- a/src/index.css
+++ b/src/index.css
@@ -821,33 +821,8 @@ body {
   }
 }
 
-/* ── Responsive: small screens ── */
+/* ── Responsive: small screens (global classes only) ── */
 @media (max-width: 768px) {
-  .score-display {
-    top: 12px !important;
-    left: 12px !important;
-    padding: 10px 14px !important;
-  }
-
-  .score-display .score-value {
-    font-size: 1.1rem !important;
-  }
-
-  .shop-button {
-    top: 12px !important;
-    right: 12px !important;
-    padding: 8px 12px !important;
-  }
-
-  .shop-button .shop-coin-icon {
-    width: 28px !important;
-    height: 28px !important;
-  }
-
-  .shop-button .shop-coin-balance {
-    font-size: 1rem !important;
-  }
-
   .banana-tree-panel {
     top: 90px !important;
     left: 8px !important;
@@ -878,28 +853,6 @@ body {
     height: 18px !important;
   }
 
-  .upgrade-panel {
-    gap: 4px !important;
-    padding-left: 6px !important;
-    padding-right: 6px !important;
-  }
-
-  .upgrade-panel .upgrade-card-header-name {
-    font-size: 0.5rem !important;
-  }
-
-  .upgrade-panel .upgrade-card-body-label {
-    font-size: 0.52rem !important;
-  }
-
-  .upgrade-panel .upgrade-card-body-next {
-    font-size: 0.68rem !important;
-  }
-
-  .upgrade-panel .upgrade-card-cost-pill {
-    font-size: 0.56rem !important;
-  }
-
   .skill-choose-panel {
     width: 160px !important;
   }
@@ -915,7 +868,7 @@ body {
   }
 }
 
-/* ── Responsive: very small screens ── */
+/* ── Responsive: very small screens (global classes only) ── */
 @media (max-width: 480px) {
   .banana-tree-panel {
     top: 80px !important;
@@ -966,15 +919,6 @@ body {
 
   .unlocked-tiers-panel .tier-score {
     display: none !important;
-  }
-
-  .shop-button .shop-label,
-  .shop-button .shop-divider {
-    display: none !important;
-  }
-
-  .score-display .per-second-label {
-    font-size: 0.55rem !important;
   }
 
   .logout-button {

--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,7 @@ body {
 }
 
 /* Auth screen animations */
-@keyframes bananaFall {
+@keyframes banana-fall {
   0% {
     transform: translateY(0) rotate(var(--r, 0deg));
     opacity: 0;
@@ -117,7 +117,7 @@ body {
   }
 }
 
-@keyframes bananaFloat {
+@keyframes banana-float {
   0%,
   100% {
     transform: translateY(0) rotate(-8deg);
@@ -128,7 +128,7 @@ body {
   }
 }
 
-@keyframes loaderPulse {
+@keyframes loader-pulse {
   0%,
   100% {
     transform: scaleX(1);
@@ -141,7 +141,7 @@ body {
   }
 }
 
-@keyframes authSlideInRight {
+@keyframes auth-slide-in-right {
   from {
     transform: translateX(20px);
     opacity: 0;
@@ -153,7 +153,7 @@ body {
   }
 }
 
-@keyframes authSlideInLeft {
+@keyframes auth-slide-in-left {
   from {
     transform: translateX(-20px);
     opacity: 0;
@@ -195,7 +195,7 @@ body {
   border: 1px solid var(--accent-gold-soft);
   padding: 8px 16px;
   border-radius: 8px;
-  font-family: 'Outfit', sans-serif;
+  font-family: Outfit, sans-serif;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -945,7 +945,7 @@ body {
   color: var(--text-muted);
   font-size: 0.6rem;
   font-weight: 700;
-  font-family: 'Outfit', sans-serif;
+  font-family: Outfit, sans-serif;
   letter-spacing: 0.04em;
   cursor: pointer;
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -821,6 +821,205 @@ body {
   }
 }
 
+/* ── Responsive: small screens ── */
+@media (max-width: 768px) {
+  .score-display {
+    top: 12px !important;
+    left: 12px !important;
+    padding: 10px 14px !important;
+  }
+
+  .score-display .score-value {
+    font-size: 1.1rem !important;
+  }
+
+  .shop-button {
+    top: 12px !important;
+    right: 12px !important;
+    padding: 8px 12px !important;
+  }
+
+  .shop-button .shop-coin-icon {
+    width: 28px !important;
+    height: 28px !important;
+  }
+
+  .shop-button .shop-coin-balance {
+    font-size: 1rem !important;
+  }
+
+  .banana-tree-panel {
+    top: 90px !important;
+    left: 8px !important;
+  }
+
+  .banana-tree-main {
+    width: 120px !important;
+    padding: 10px 10px !important;
+  }
+
+  .banana-tree-main .tree-image {
+    width: 90px !important;
+    height: 90px !important;
+  }
+
+  .unlocked-tiers-panel {
+    top: 90px !important;
+    right: 8px !important;
+  }
+
+  .unlocked-tiers-panel .tier-card {
+    padding: 4px 8px !important;
+    font-size: 0.65rem !important;
+  }
+
+  .unlocked-tiers-panel .tier-icon {
+    width: 18px !important;
+    height: 18px !important;
+  }
+
+  .upgrade-panel {
+    gap: 4px !important;
+    padding-left: 6px !important;
+    padding-right: 6px !important;
+  }
+
+  .upgrade-panel .upgrade-card-header-name {
+    font-size: 0.5rem !important;
+  }
+
+  .upgrade-panel .upgrade-card-body-label {
+    font-size: 0.52rem !important;
+  }
+
+  .upgrade-panel .upgrade-card-body-next {
+    font-size: 0.68rem !important;
+  }
+
+  .upgrade-panel .upgrade-card-cost-pill {
+    font-size: 0.56rem !important;
+  }
+
+  .skill-choose-panel {
+    width: 160px !important;
+  }
+
+  .effect-status-label {
+    font-size: 0.6rem !important;
+    padding: 3px 10px !important;
+  }
+
+  .logout-button {
+    top: 8px !important;
+    right: 12px !important;
+  }
+}
+
+/* ── Responsive: very small screens ── */
+@media (max-width: 480px) {
+  .banana-tree-panel {
+    top: 80px !important;
+    left: 4px !important;
+  }
+
+  .banana-tree-main {
+    width: 100px !important;
+    padding: 8px 6px !important;
+  }
+
+  .banana-tree-main .tree-image {
+    width: 70px !important;
+    height: 70px !important;
+  }
+
+  .banana-tree-main .tree-stage-label {
+    font-size: 0.65rem !important;
+  }
+
+  .banana-tree-main .tree-lv-badge {
+    font-size: 0.5rem !important;
+  }
+
+  .banana-tree-main .water-button {
+    padding: 5px 10px !important;
+    font-size: 0.6rem !important;
+  }
+
+  .unlocked-tiers-panel {
+    top: 80px !important;
+    right: 4px !important;
+  }
+
+  .unlocked-tiers-panel .tier-card {
+    padding: 3px 6px !important;
+    font-size: 0.6rem !important;
+  }
+
+  .unlocked-tiers-panel .section-label {
+    font-size: 0.5rem !important;
+  }
+
+  .unlocked-tiers-panel .tier-icon {
+    width: 16px !important;
+    height: 16px !important;
+  }
+
+  .unlocked-tiers-panel .tier-score {
+    display: none !important;
+  }
+
+  .shop-button .shop-label,
+  .shop-button .shop-divider {
+    display: none !important;
+  }
+
+  .score-display .per-second-label {
+    font-size: 0.55rem !important;
+  }
+
+  .logout-button {
+    top: 4px !important;
+    right: 8px !important;
+    font-size: 9px !important;
+    padding: 3px 8px !important;
+  }
+}
+
+/* ── Logout button ── */
+.logout-button {
+  position: fixed;
+  top: 12px;
+  right: 24px;
+  z-index: 1001;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border-radius: 20px;
+  border: none;
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text-muted);
+  font-size: 0.6rem;
+  font-weight: 700;
+  font-family: 'Outfit', sans-serif;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.logout-button:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--text-main);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.logout-button:active {
+  transform: scale(0.96);
+}
+
 /* Custom Scrollbar for premium feel */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
+import { AuthProvider } from './contexts/AuthContext';
+import AuthGate from './components/auth/AuthGate';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <AuthGate>
+        <App />
+      </AuthGate>
+    </AuthProvider>
   </StrictMode>,
 );

--- a/src/services/cognitoAuth.js
+++ b/src/services/cognitoAuth.js
@@ -1,0 +1,81 @@
+import {
+  CognitoUserPool,
+  CognitoUser,
+  AuthenticationDetails,
+  CognitoUserAttribute,
+} from 'amazon-cognito-identity-js';
+
+const userPool = new CognitoUserPool({
+  UserPoolId: import.meta.env.VITE_COGNITO_USER_POOL_ID,
+  ClientId: import.meta.env.VITE_COGNITO_CLIENT_ID,
+});
+
+export function signUp(email, password) {
+  return new Promise((resolve, reject) => {
+    const attributes = [
+      new CognitoUserAttribute({ Name: 'email', Value: email }),
+    ];
+
+    userPool.signUp(email, password, attributes, null, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+}
+
+export function confirmSignUp(email, code) {
+  const cognitoUser = new CognitoUser({
+    Username: email,
+    Pool: userPool,
+  });
+
+  return new Promise((resolve, reject) => {
+    cognitoUser.confirmRegistration(code, true, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+}
+
+export function signIn(email, password) {
+  const cognitoUser = new CognitoUser({
+    Username: email,
+    Pool: userPool,
+  });
+
+  const authDetails = new AuthenticationDetails({
+    Username: email,
+    Password: password,
+  });
+
+  return new Promise((resolve, reject) => {
+    cognitoUser.authenticateUser(authDetails, {
+      onSuccess: (session) => resolve(session),
+      onFailure: (err) => reject(err),
+    });
+  });
+}
+
+export function signOut() {
+  const cognitoUser = userPool.getCurrentUser();
+  if (cognitoUser) {
+    cognitoUser.signOut();
+  }
+}
+
+export function getCurrentSession() {
+  return new Promise((resolve, reject) => {
+    const cognitoUser = userPool.getCurrentUser();
+    if (!cognitoUser) return resolve(null);
+
+    cognitoUser.getSession((err, session) => {
+      if (err) return reject(err);
+      if (!session.isValid()) return resolve(null);
+      resolve(session);
+    });
+  });
+}
+
+export function getCurrentUser() {
+  return userPool.getCurrentUser();
+}

--- a/src/services/cognitoAuth.js
+++ b/src/services/cognitoAuth.js
@@ -15,6 +15,8 @@ const userPool = isCognitoConfigured
   : null;
 
 export function signUp(email, password) {
+  if (!userPool) return Promise.reject(new Error('Cognito is not configured'));
+
   return new Promise((resolve, reject) => {
     const attributes = [
       new CognitoUserAttribute({ Name: 'email', Value: email }),
@@ -28,6 +30,8 @@ export function signUp(email, password) {
 }
 
 export function confirmSignUp(email, code) {
+  if (!userPool) return Promise.reject(new Error('Cognito is not configured'));
+
   const cognitoUser = new CognitoUser({
     Username: email,
     Pool: userPool,
@@ -42,6 +46,8 @@ export function confirmSignUp(email, code) {
 }
 
 export function signIn(email, password) {
+  if (!userPool) return Promise.reject(new Error('Cognito is not configured'));
+
   const cognitoUser = new CognitoUser({
     Username: email,
     Pool: userPool,
@@ -61,6 +67,8 @@ export function signIn(email, password) {
 }
 
 export function signOut() {
+  if (!userPool) return;
+
   const cognitoUser = userPool.getCurrentUser();
   if (cognitoUser) {
     cognitoUser.signOut();
@@ -68,6 +76,8 @@ export function signOut() {
 }
 
 export function getCurrentSession() {
+  if (!userPool) return Promise.resolve(null);
+
   return new Promise((resolve, reject) => {
     const cognitoUser = userPool.getCurrentUser();
     if (!cognitoUser) return resolve(null);
@@ -81,5 +91,7 @@ export function getCurrentSession() {
 }
 
 export function getCurrentUser() {
+  if (!userPool) return null;
+
   return userPool.getCurrentUser();
 }

--- a/src/services/cognitoAuth.js
+++ b/src/services/cognitoAuth.js
@@ -5,10 +5,14 @@ import {
   CognitoUserAttribute,
 } from 'amazon-cognito-identity-js';
 
-const userPool = new CognitoUserPool({
-  UserPoolId: import.meta.env.VITE_COGNITO_USER_POOL_ID,
-  ClientId: import.meta.env.VITE_COGNITO_CLIENT_ID,
-});
+const POOL_ID = import.meta.env.VITE_COGNITO_USER_POOL_ID;
+const CLIENT_ID = import.meta.env.VITE_COGNITO_CLIENT_ID;
+
+export const isCognitoConfigured = !!(POOL_ID && CLIENT_ID);
+
+const userPool = isCognitoConfigured
+  ? new CognitoUserPool({ UserPoolId: POOL_ID, ClientId: CLIENT_ID })
+  : null;
 
 export function signUp(email, password) {
   return new Promise((resolve, reject) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   base: '/bananadrop/',
+  define: {
+    global: 'globalThis',
+  },
 });


### PR DESCRIPTION
## 概要

Cognito User Pool によるメール/パスワード認証を構築し、サインアップ・ログイン・メール確認のフロントエンド UI を実装。GitHub Pages 環境では認証なしで動作するよう条件分岐も対応。

## 関連イシュー

Closes #87

## 変更内容

### インフラ (Terraform)
- `infra/cognito.tf` — Cognito User Pool + SPA App Client (MFA無効、Access 1h / Refresh 30d)
- `infra/outputs.tf` — `cognito_user_pool_id` / `cognito_client_id` 出力追加

### フロントエンド (認証)
- `src/services/cognitoAuth.js` — Cognito 操作サービス (signUp / confirmSignUp / signIn / signOut / getSession)
- `src/contexts/AuthContext.jsx` + `src/hooks/useAuth.js` — 認証状態管理
- `src/components/auth/` — ログイン・サインアップ・メール確認フォーム（日本語、バナナテーマデザイン）
- `src/components/auth/AuthGate.jsx` — 認証ガード（未ログイン時は AuthScreen を表示）
- `src/main.jsx` — AuthProvider + AuthGate でラップ
- `src/App.jsx` — ログアウトボタン追加 (authEnabled 時のみ表示)

### 環境変数
- `.env.example` — `VITE_COGNITO_USER_POOL_ID` / `VITE_COGNITO_CLIENT_ID` テンプレート追加
- `.gitignore` — `.env` / `.env.*` 追加

### GitHub Pages 対応
- 環境変数未設定時は `isCognitoConfigured = false` となり認証をスキップ
- GitHub Pages ビルドは Cognito 環境変数を設定しないだけで認証なしで動作

### その他
- `vite.config.js` — `global: 'globalThis'` polyfill 追加 (amazon-cognito-identity-js 対応)
- UI コンポーネントのアクセシビリティ改善 (セマンティックHTML、aria属性)

## 備考

- `.env.local` はローカル開発用（gitignore 済み）。`terraform output` で取得した値を設定する
- API Gateway / Lambda / DynamoDB は後続イシューで対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メール認証（サインアップ／確認コード／ログイン／ログアウト）と認証ゲートを追加しました
  * 認証コンテキストとフックを導入しました

* **ドキュメント**
  * 環境変数サンプルを追加し README 表記を微修正しました

* **バグ修正／改善**
  * アクセシビリティ強化（role/aria属性、装飾の明示化）
  * UI を CSS モジュール化しレスポンシブ対応を強化しました

* **その他**
  * Cognito 用のインフラ出力とランタイム依存を追加、環境ファイルの無視設定を更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->