### PR TITLE
Build backend API with DynamoDB, Lambda, and API Gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 
 # Terraform
 infra/.terraform/
+infra/.build/
 *.tfstate
 *.tfstate.*
 *.tfvars

--- a/infra/apigateway.tf
+++ b/infra/apigateway.tf
@@ -4,7 +4,8 @@ resource "aws_apigatewayv2_api" "main" {
   name          = "${var.project_name}-api"
   protocol_type = "HTTP"
 
-  # CloudFront 経由のアクセスが前提だが、ローカル開発時の直接アクセスにも対応するため CORS を許可
+  # CloudFront 経由のアクセスが前提（same-origin のため通常 CORS 不要だが、
+  # API Gateway 直接アクセス時のフォールバックとして設定）
   cors_configuration {
     allow_origins = ["https://${aws_cloudfront_distribution.main.domain_name}"]
     allow_methods = ["GET", "POST", "PUT", "OPTIONS"]

--- a/infra/apigateway.tf
+++ b/infra/apigateway.tf
@@ -3,15 +3,8 @@
 resource "aws_apigatewayv2_api" "main" {
   name          = "${var.project_name}-api"
   protocol_type = "HTTP"
-
-  # CloudFront 経由のアクセスが前提（same-origin のため通常 CORS 不要だが、
-  # API Gateway 直接アクセス時のフォールバックとして設定）
-  cors_configuration {
-    allow_origins = ["https://${aws_cloudfront_distribution.main.domain_name}"]
-    allow_methods = ["GET", "POST", "PUT", "OPTIONS"]
-    allow_headers = ["Authorization", "Content-Type"]
-    max_age       = 86400
-  }
+  # CORS は CloudFront 経由の same-origin アクセスが前提のため設定しない。
+  # API Gateway への直接アクセスは想定していない。
 }
 
 # --- JWT Authorizer (Cognito) ---

--- a/infra/apigateway.tf
+++ b/infra/apigateway.tf
@@ -1,0 +1,74 @@
+# --- HTTP API ---
+
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${var.project_name}-api"
+  protocol_type = "HTTP"
+}
+
+# --- JWT Authorizer (Cognito) ---
+
+resource "aws_apigatewayv2_authorizer" "cognito" {
+  api_id           = aws_apigatewayv2_api.main.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "cognito-jwt"
+
+  jwt_configuration {
+    issuer   = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}"
+    audience = [aws_cognito_user_pool_client.spa.id]
+  }
+}
+
+# --- Lambda integration ---
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.api.invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+# --- Routes ---
+
+resource "aws_apigatewayv2_route" "get_save" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "GET /api/save"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+resource "aws_apigatewayv2_route" "post_save" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "POST /api/save"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+resource "aws_apigatewayv2_route" "get_leaderboard" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "GET /api/leaderboard"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+# --- Auto-deploy stage ---
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+# --- Lambda permission for API Gateway ---
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*/*"
+}

--- a/infra/apigateway.tf
+++ b/infra/apigateway.tf
@@ -3,6 +3,14 @@
 resource "aws_apigatewayv2_api" "main" {
   name          = "${var.project_name}-api"
   protocol_type = "HTTP"
+
+  # CloudFront 経由のアクセスが前提だが、ローカル開発時の直接アクセスにも対応するため CORS を許可
+  cors_configuration {
+    allow_origins = ["https://${aws_cloudfront_distribution.main.domain_name}"]
+    allow_methods = ["GET", "POST", "PUT", "OPTIONS"]
+    allow_headers = ["Authorization", "Content-Type"]
+    max_age       = 86400
+  }
 }
 
 # --- JWT Authorizer (Cognito) ---
@@ -50,6 +58,14 @@ resource "aws_apigatewayv2_route" "post_save" {
 resource "aws_apigatewayv2_route" "get_leaderboard" {
   api_id             = aws_apigatewayv2_api.main.id
   route_key          = "GET /api/leaderboard"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+resource "aws_apigatewayv2_route" "put_profile" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "PUT /api/profile"
   target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -10,6 +10,31 @@ resource "aws_cloudfront_distribution" "main" {
     origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
   }
 
+  # API Gateway Origin
+  origin {
+    domain_name = replace(aws_apigatewayv2_api.main.api_endpoint, "https://", "")
+    origin_id   = "api-gateway"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # API behavior (/api/*) — no caching, forward auth headers
+  ordered_cache_behavior {
+    path_pattern             = "/api/*"
+    target_origin_id         = "api-gateway"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
+    compress                 = true
+  }
+
   # Default behavior (S3)
   default_cache_behavior {
     target_origin_id       = "s3-frontend"
@@ -49,4 +74,14 @@ resource "aws_cloudfront_distribution" "main" {
   viewer_certificate {
     cloudfront_default_certificate = true
   }
+}
+
+# AWS Managed Cache Policy: CachingDisabled
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+# AWS Managed Origin Request Policy: AllViewerExceptHostHeader
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host" {
+  name = "Managed-AllViewerExceptHostHeader"
 }

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -24,6 +24,10 @@ resource "aws_dynamodb_table" "main" {
     type = "N"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   global_secondary_index {
     name            = "leaderboard-index"
     hash_key        = "leaderboardKey"

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -1,0 +1,36 @@
+resource "aws_dynamodb_table" "main" {
+  name         = var.project_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  attribute {
+    name = "leaderboardKey"
+    type = "S"
+  }
+
+  attribute {
+    name = "score"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name            = "leaderboard-index"
+    hash_key        = "leaderboardKey"
+    range_key       = "score"
+    projection_type = "INCLUDE"
+    non_key_attributes = [
+      "userName",
+    ]
+  }
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -136,6 +136,33 @@ resource "aws_iam_role_policy" "infra_resources" {
         Action   = ["cognito-idp:*"]
         Resource = "arn:aws:cognito-idp:${var.aws_region}:${data.aws_caller_identity.current.account_id}:userpool/*"
       },
+      {
+        Sid      = "LambdaManagement"
+        Effect   = "Allow"
+        Action   = ["lambda:*"]
+        Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${var.project_name}-*"
+      },
+      {
+        Sid    = "ApiGatewayManagement"
+        Effect = "Allow"
+        Action = ["apigateway:*"]
+        Resource = [
+          "arn:aws:apigateway:${var.aws_region}::/apis",
+          "arn:aws:apigateway:${var.aws_region}::/apis/*",
+        ]
+      },
+      {
+        Sid      = "DynamoDBManagement"
+        Effect   = "Allow"
+        Action   = ["dynamodb:*"]
+        Resource = "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.project_name}*"
+      },
+      {
+        Sid      = "CloudWatchLogsManagement"
+        Effect   = "Allow"
+        Action   = ["logs:*"]
+        Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.project_name}-*"
+      },
     ]
   })
 }

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -104,6 +104,10 @@ resource "aws_iam_role_policy" "infra_resources" {
           "cloudfront:UpdateOriginAccessControl",
           "cloudfront:ListOriginAccessControls",
           "cloudfront:CreateInvalidation",
+          "cloudfront:ListCachePolicies",
+          "cloudfront:GetCachePolicy",
+          "cloudfront:ListOriginRequestPolicies",
+          "cloudfront:GetOriginRequestPolicy",
         ]
         Resource = "*"
       },

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -29,6 +29,7 @@ resource "aws_iam_role_policy" "lambda_dynamodb" {
         Action = [
           "dynamodb:GetItem",
           "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
           "dynamodb:Query",
         ]
         Resource = [

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,82 @@
+# --- Lambda execution role ---
+
+resource "aws_iam_role" "lambda_exec" {
+  name = "${var.project_name}-lambda-exec"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_dynamodb" {
+  name = "dynamodb-access"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:Query",
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# --- CloudWatch log group ---
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.project_name}-api"
+  retention_in_days = 30
+}
+
+# --- Lambda function ---
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda"
+  output_path = "${path.module}/.build/lambda.zip"
+}
+
+resource "aws_lambda_function" "api" {
+  function_name    = "${var.project_name}-api"
+  role             = aws_iam_role.lambda_exec.arn
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  memory_size      = 128
+  timeout          = 10
+  filename         = data.archive_file.lambda.output_path
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+
+  environment {
+    variables = {
+      TABLE_NAME = aws_dynamodb_table.main.name
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.lambda,
+  ]
+}

--- a/infra/lambda/index.mjs
+++ b/infra/lambda/index.mjs
@@ -146,7 +146,10 @@ async function handlePutProfile(sub, rawBody) {
 // ユーザーが入力したユーザー名を検証・整形する（日本語対応、最大20文字）
 function sanitizeUserName(raw) {
   if (typeof raw !== 'string') return null;
-  const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, '').trim();
+  const cleaned = raw
+    .replace(/[\x00-\x1F\x7F]/g, '')
+    .replace(/<[^>]*>/g, '')
+    .trim();
   if (cleaned.length === 0 || cleaned.length > 20) return null;
   return cleaned;
 }

--- a/infra/lambda/index.mjs
+++ b/infra/lambda/index.mjs
@@ -69,7 +69,12 @@ function autoUserName(sub) {
 
 // POST /api/save — save player game state
 async function handlePostSave(sub, rawBody) {
-  const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+  let body;
+  try {
+    body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+  } catch {
+    return response(400, { error: 'Invalid JSON in request body' });
+  }
 
   if (!body || !body.gameState) {
     return response(400, { error: 'Missing gameState in request body' });
@@ -112,7 +117,12 @@ async function handlePostSave(sub, rawBody) {
 
 // PUT /api/profile — ユーザー名を変更する
 async function handlePutProfile(sub, rawBody) {
-  const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+  let body;
+  try {
+    body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+  } catch {
+    return response(400, { error: 'Invalid JSON in request body' });
+  }
   const cleaned = sanitizeUserName(body?.userName);
 
   if (!cleaned) {

--- a/infra/lambda/index.mjs
+++ b/infra/lambda/index.mjs
@@ -1,0 +1,123 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+
+const client = new DynamoDBClient({});
+const ddb = DynamoDBDocumentClient.from(client);
+const TABLE_NAME = process.env.TABLE_NAME;
+
+export async function handler(event) {
+  const method = event.requestContext?.http?.method;
+  const path = event.requestContext?.http?.path;
+  const sub = event.requestContext?.authorizer?.jwt?.claims?.sub;
+
+  if (!sub) {
+    return response(401, { error: 'Unauthorized' });
+  }
+
+  try {
+    if (path === '/api/save' && method === 'GET') {
+      return await handleGetSave(sub);
+    }
+    if (path === '/api/save' && method === 'POST') {
+      return await handlePostSave(sub, event.body);
+    }
+    if (path === '/api/leaderboard' && method === 'GET') {
+      return await handleGetLeaderboard();
+    }
+    return response(404, { error: 'Not found' });
+  } catch (err) {
+    console.error('Handler error:', err);
+    return response(500, { error: 'Internal server error' });
+  }
+}
+
+// GET /api/save — load player save data
+async function handleGetSave(sub) {
+  const result = await ddb.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { pk: `USER#${sub}`, sk: 'SAVE#01' },
+    }),
+  );
+
+  if (!result.Item) {
+    return response(200, { exists: false, gameState: null });
+  }
+
+  return response(200, {
+    exists: true,
+    gameState: result.Item.gameState,
+    userName: result.Item.userName,
+    updatedAt: result.Item.updatedAt,
+  });
+}
+
+// POST /api/save — save player game state
+async function handlePostSave(sub, rawBody) {
+  const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+
+  if (!body || !body.gameState) {
+    return response(400, { error: 'Missing gameState in request body' });
+  }
+
+  const { gameState, userName } = body;
+  const now = new Date().toISOString();
+
+  // Extract score for leaderboard GSI
+  const score = typeof gameState.score === 'number' ? gameState.score : 0;
+
+  await ddb.send(
+    new PutCommand({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: `USER#${sub}`,
+        sk: 'SAVE#01',
+        userName: userName || 'Anonymous',
+        score,
+        leaderboardKey: 'GLOBAL',
+        gameState,
+        schemaVersion: '1',
+        createdAt: now,
+        updatedAt: now,
+      },
+    }),
+  );
+
+  return response(200, { success: true, updatedAt: now });
+}
+
+// GET /api/leaderboard — top N players
+async function handleGetLeaderboard() {
+  const result = await ddb.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'leaderboard-index',
+      KeyConditionExpression: 'leaderboardKey = :gk',
+      ExpressionAttributeValues: { ':gk': 'GLOBAL' },
+      ScanIndexForward: false,
+      Limit: 20,
+      ProjectionExpression: 'userName, score',
+    }),
+  );
+
+  return response(200, {
+    entries: (result.Items || []).map((item, i) => ({
+      rank: i + 1,
+      userName: item.userName,
+      score: item.score,
+    })),
+  });
+}
+
+function response(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}

--- a/infra/lambda/index.mjs
+++ b/infra/lambda/index.mjs
@@ -2,7 +2,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
   GetCommand,
-  PutCommand,
+  UpdateCommand,
   QueryCommand,
 } from '@aws-sdk/lib-dynamodb';
 
@@ -26,6 +26,9 @@ export async function handler(event) {
     if (path === '/api/save' && method === 'POST') {
       return await handlePostSave(sub, event.body);
     }
+    if (path === '/api/profile' && method === 'PUT') {
+      return await handlePutProfile(sub, event.body);
+    }
     if (path === '/api/leaderboard' && method === 'GET') {
       return await handleGetLeaderboard();
     }
@@ -41,6 +44,7 @@ async function handleGetSave(sub) {
   const result = await ddb.send(
     new GetCommand({
       TableName: TABLE_NAME,
+      // sk は 'SAVE#01' 固定 — セーブスロットは1つのみの設計
       Key: { pk: `USER#${sub}`, sk: 'SAVE#01' },
     }),
   );
@@ -57,6 +61,12 @@ async function handleGetSave(sub) {
   });
 }
 
+// sub の先頭6文字からプレイヤー表示名を自動生成する
+// （ユーザーが意識する必要なく、メールアドレスを公開しない匿名識別子）
+function autoUserName(sub) {
+  return `Player-${sub.replace(/-/g, '').slice(0, 6)}`;
+}
+
 // POST /api/save — save player game state
 async function handlePostSave(sub, rawBody) {
   const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
@@ -65,30 +75,80 @@ async function handlePostSave(sub, rawBody) {
     return response(400, { error: 'Missing gameState in request body' });
   }
 
-  const { gameState, userName } = body;
+  const { gameState } = body;
   const now = new Date().toISOString();
 
   // Extract score for leaderboard GSI
   const score = typeof gameState.score === 'number' ? gameState.score : 0;
 
+  // UpdateCommand を使い、初回保存時のみ createdAt・userName をセット（以降は上書きしない）
   await ddb.send(
-    new PutCommand({
+    new UpdateCommand({
       TableName: TABLE_NAME,
-      Item: {
-        pk: `USER#${sub}`,
-        sk: 'SAVE#01',
-        userName: userName || 'Anonymous',
-        score,
-        leaderboardKey: 'GLOBAL',
-        gameState,
-        schemaVersion: '1',
-        createdAt: now,
-        updatedAt: now,
+      // sk は 'SAVE#01' 固定 — セーブスロットは1つのみの設計
+      Key: { pk: `USER#${sub}`, sk: 'SAVE#01' },
+      UpdateExpression: [
+        'SET score = :score',
+        'leaderboardKey = :lk',
+        'gameState = :gameState',
+        'schemaVersion = :sv',
+        'updatedAt = :now',
+        'createdAt = if_not_exists(createdAt, :now)',
+        'userName = if_not_exists(userName, :autoName)',
+      ].join(', '),
+      ExpressionAttributeValues: {
+        ':score': score,
+        ':lk': 'GLOBAL',
+        ':gameState': gameState,
+        ':sv': '1',
+        ':now': now,
+        ':autoName': autoUserName(sub),
       },
     }),
   );
 
   return response(200, { success: true, updatedAt: now });
+}
+
+// PUT /api/profile — ユーザー名を変更する
+async function handlePutProfile(sub, rawBody) {
+  const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+  const cleaned = sanitizeUserName(body?.userName);
+
+  if (!cleaned) {
+    return response(400, { error: 'userName は1〜20文字で入力してください' });
+  }
+
+  try {
+    await ddb.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: { pk: `USER#${sub}`, sk: 'SAVE#01' },
+        UpdateExpression: 'SET userName = :userName',
+        // セーブデータが存在するユーザーのみ更新を許可（孤立アイテムの生成を防ぐ）
+        ConditionExpression: 'attribute_exists(pk)',
+        ExpressionAttributeValues: { ':userName': cleaned },
+      }),
+    );
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      return response(404, {
+        error:
+          'セーブデータが見つかりません。一度ゲームを遊んでから設定してください。',
+      });
+    }
+    throw err;
+  }
+
+  return response(200, { success: true, userName: cleaned });
+}
+
+// ユーザーが入力したユーザー名を検証・整形する（日本語対応、最大20文字）
+function sanitizeUserName(raw) {
+  if (typeof raw !== 'string') return null;
+  const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, '').trim();
+  if (cleaned.length === 0 || cleaned.length > 20) return null;
+  return cleaned;
 }
 
 // GET /api/leaderboard — top N players

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -32,3 +32,13 @@ output "cognito_client_id" {
   description = "Cognito App Client ID"
   value       = aws_cognito_user_pool_client.spa.id
 }
+
+output "api_gateway_endpoint" {
+  description = "API Gateway HTTP API endpoint"
+  value       = aws_apigatewayv2_api.main.api_endpoint
+}
+
+output "dynamodb_table_name" {
+  description = "DynamoDB table name"
+  value       = aws_dynamodb_table.main.name
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,8 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useAuth } from './hooks/useAuth';
+import { useSaveSync } from './hooks/useSaveSync';
+import { autoUserName } from './services/saveApi';
+import ProfileModal from './components/auth/ProfileModal';
 import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
 import FeverBurst from './components/ui/FeverBurst';
@@ -43,6 +46,7 @@ function App() {
     purchased,
     buyUpgrade,
     treeLevel,
+    treeChosenStages,
     banaCoins,
     treeGrowth,
     waterCount,
@@ -55,6 +59,7 @@ function App() {
     buyShopItem,
     adjustCoins,
     resetUpgrades,
+    restoreState,
   } = useUpgradeState();
 
   const {
@@ -96,6 +101,63 @@ function App() {
     0,
   );
 
+  // score の最新値を非同期コールバックから参照するための ref
+  const scoreRef = useRef(score);
+  scoreRef.current = score;
+
+  const getGameState = useCallback(
+    () => ({
+      score: scoreRef.current,
+      purchased: Array.from(purchased),
+      bananaPerClick,
+      autoSpawnRate,
+      giantChance,
+      unlockedTierIds: unlockedTiers.map((t) => t.tier),
+      treeLevel,
+      treeGrowth,
+      banaCoins,
+      waterCount,
+      chosenSkills: treeChosenSkills,
+      chosenStages: treeChosenStages,
+      shopPurchases,
+    }),
+    [
+      purchased,
+      bananaPerClick,
+      autoSpawnRate,
+      giantChance,
+      unlockedTiers,
+      treeLevel,
+      treeGrowth,
+      banaCoins,
+      waterCount,
+      treeChosenSkills,
+      treeChosenStages,
+      shopPurchases,
+    ],
+  );
+
+  const restoreGame = useCallback(
+    (gs) => {
+      restoreState(gs);
+      setScore(gs.score ?? 0);
+    },
+    [restoreState],
+  );
+
+  useSaveSync({
+    user,
+    getGameState,
+    restoreGame,
+    onSaveLoaded: (data) => {
+      if (data.userName) {
+        setUserName(data.userName);
+      } else if (user?.sub) {
+        setUserName(autoUserName(user.sub));
+      }
+    },
+  });
+
   const bananaWorldRef = useRef(null);
 
   const [floatingTexts, setFloatingTexts] = useState([]);
@@ -107,6 +169,9 @@ function App() {
   const [perSecond, setPerSecond] = useState(0);
   const [devMode, setDevMode] = useState(false);
   const [isShopOpen, setIsShopOpen] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [userName, setUserName] = useState(null);
+  const [floatingCoins, setFloatingCoins] = useState([]);
 
   // 開発者モード: Ctrl+Shift+D で切り替え
   useEffect(() => {
@@ -144,8 +209,6 @@ function App() {
     }
     prevTreeLevelRef.current = treeLevel;
   }, [treeLevel]);
-
-  const [floatingCoins, setFloatingCoins] = useState([]);
 
   const handleCoinCollected = useCallback(
     (x) => {
@@ -386,32 +449,80 @@ function App() {
       onClick={handleClick}
     >
       {authEnabled && (
-        <button
-          className="logout-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            signOut();
+        <div
+          style={{
+            position: 'fixed',
+            top: 12,
+            right: 12,
+            zIndex: 50,
+            display: 'flex',
+            gap: 6,
           }}
-          aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
-          title={user?.email}
+          onClick={(e) => e.stopPropagation()}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
+          <button
+            className="logout-button"
+            onClick={() => setIsProfileOpen(true)}
+            aria-label="プロフィール設定"
+            title={userName ?? ''}
+            style={{ gap: 5 }}
           >
-            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-            <polyline points="16 17 21 12 16 7" />
-            <line x1="21" y1="12" x2="9" y2="12" />
-          </svg>
-          <span>Logout</span>
-        </button>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="8" r="4" />
+              <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+            </svg>
+            <span
+              style={{
+                maxWidth: 80,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {userName ?? '…'}
+            </span>
+          </button>
+          <button
+            className="logout-button"
+            onClick={signOut}
+            aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
+            title={user?.email}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
+            <span>Logout</span>
+          </button>
+        </div>
+      )}
+      {isProfileOpen && (
+        <ProfileModal
+          userName={userName}
+          onClose={() => setIsProfileOpen(false)}
+          onSaved={(newName) => setUserName(newName)}
+        />
       )}
       <ScoreDisplay
         score={score}

--- a/src/components/auth/ProfileModal.jsx
+++ b/src/components/auth/ProfileModal.jsx
@@ -1,0 +1,269 @@
+import { useState } from 'react';
+import { putProfile } from '../../services/saveApi';
+
+const MAX_LENGTH = 20;
+
+export default function ProfileModal({ userName, onClose, onSaved }) {
+  const [value, setValue] = useState(userName ?? '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [focused, setFocused] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError('ユーザー名を入力してください');
+      return;
+    }
+    if (trimmed.length > MAX_LENGTH) {
+      setError(`${MAX_LENGTH}文字以内で入力してください`);
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const result = await putProfile(trimmed);
+      onSaved(result.userName);
+      onClose();
+    } catch (err) {
+      setError(err.message ?? '保存に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="プロフィール設定"
+      style={styles.overlay}
+      onClick={onClose}
+    >
+      <div
+        className="glass-panel"
+        style={styles.panel}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div style={styles.header}>
+          <span style={styles.title}>プロフィール</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            style={styles.closeButton}
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} style={styles.form}>
+          {error && (
+            <div style={styles.error}>
+              <span style={styles.errorIcon}>!</span>
+              {error}
+            </div>
+          )}
+
+          <div style={styles.fieldGroup}>
+            <label htmlFor="profile-username" style={styles.label}>
+              ユーザー名
+            </label>
+            <div
+              style={{
+                ...styles.inputWrap,
+                ...(focused ? styles.inputWrapFocused : {}),
+              }}
+            >
+              <span style={styles.inputIcon}>🍌</span>
+              <input
+                id="profile-username"
+                type="text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                maxLength={MAX_LENGTH}
+                placeholder="表示名を入力（日本語可）"
+                style={styles.input}
+                autoComplete="off"
+              />
+              <span style={styles.counter}>
+                {value.length}/{MAX_LENGTH}
+              </span>
+            </div>
+            <p style={styles.hint}>リーダーボードに表示される名前です</p>
+          </div>
+
+          <button type="submit" disabled={isSubmitting} style={styles.button}>
+            <span style={styles.buttonText}>
+              {isSubmitting ? '保存中...' : '保存する'}
+            </span>
+            {!isSubmitting && <span style={styles.buttonIcon}>→</span>}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  overlay: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 100,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(0,0,0,0.45)',
+    backdropFilter: 'blur(4px)',
+    WebkitBackdropFilter: 'blur(4px)',
+  },
+  panel: {
+    width: 'min(380px, 92vw)',
+    borderRadius: '28px',
+    padding: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 20,
+    background: 'rgba(255,255,255,0.94)',
+    border: '1px solid var(--accent-gold-soft)',
+    boxShadow: '0 24px 64px rgba(0,0,0,0.18)',
+    animation: 'slideInModal 0.25s cubic-bezier(0.16, 1, 0.3, 1)',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontSize: '18px',
+    fontWeight: 800,
+    color: '#3a3020',
+    letterSpacing: '0.02em',
+  },
+  closeButton: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '14px',
+    color: '#8a7a60',
+    padding: '4px 8px',
+    borderRadius: '8px',
+    transition: 'background 0.15s',
+    fontFamily: 'inherit',
+  },
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+  },
+  fieldGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  label: {
+    fontSize: '12px',
+    fontWeight: 700,
+    color: '#8a7a60',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    paddingLeft: '2px',
+  },
+  inputWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '0 14px',
+    borderRadius: '12px',
+    border: '1.5px solid rgba(212, 175, 55, 0.15)',
+    background: 'rgba(255, 253, 240, 0.6)',
+    transition: 'all 0.25s ease',
+  },
+  inputWrapFocused: {
+    borderColor: 'rgba(212, 175, 55, 0.5)',
+    background: 'rgba(255, 253, 240, 0.9)',
+    boxShadow: '0 0 0 3px rgba(212, 175, 55, 0.1)',
+  },
+  inputIcon: {
+    fontSize: '14px',
+    flexShrink: 0,
+  },
+  input: {
+    flex: 1,
+    padding: '12px 0',
+    border: 'none',
+    background: 'transparent',
+    fontSize: '15px',
+    color: '#4a4a4a',
+    outline: 'none',
+    fontFamily: "'Outfit', sans-serif",
+  },
+  counter: {
+    fontSize: '11px',
+    color: '#bba880',
+    flexShrink: 0,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  hint: {
+    margin: 0,
+    fontSize: '11px',
+    color: '#bba880',
+    paddingLeft: '2px',
+  },
+  button: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '8px',
+    padding: '14px',
+    borderRadius: '14px',
+    border: 'none',
+    background:
+      'linear-gradient(135deg, #d4af37 0%, #e8c84a 50%, #b8860b 100%)',
+    color: '#fff',
+    fontSize: '16px',
+    fontWeight: 700,
+    fontFamily: "'Outfit', sans-serif",
+    cursor: 'pointer',
+    transition: 'all 0.3s ease',
+    boxShadow: '0 4px 16px rgba(212, 175, 55, 0.35)',
+  },
+  buttonText: {
+    position: 'relative',
+    zIndex: 1,
+  },
+  buttonIcon: {
+    fontSize: '18px',
+    position: 'relative',
+    zIndex: 1,
+  },
+  error: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '10px 14px',
+    borderRadius: '10px',
+    background: 'rgba(220, 38, 38, 0.06)',
+    border: '1px solid rgba(220, 38, 38, 0.12)',
+    color: '#b91c1c',
+    fontSize: '13px',
+    lineHeight: 1.4,
+  },
+  errorIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '18px',
+    height: '18px',
+    borderRadius: '50%',
+    background: '#dc2626',
+    color: '#fff',
+    fontSize: '11px',
+    fontWeight: 800,
+    flexShrink: 0,
+  },
+};

--- a/src/hooks/useSaveSync.js
+++ b/src/hooks/useSaveSync.js
@@ -28,6 +28,14 @@ export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
     onSaveLoadedRef.current = onSaveLoaded;
   });
 
+  // ログイン時にトークンを即時キャッシュ（beforeunload が最初の定期セーブ前に来ても保存できるよう）
+  useEffect(() => {
+    if (!isCognitoConfigured || !user) return;
+    getAccessToken().then((token) => {
+      if (token) tokenRef.current = token;
+    });
+  }, [user]);
+
   // ログイン時に自動ロード（1セッションに1回のみ）
   useEffect(() => {
     if (!isCognitoConfigured || !user || hasLoadedRef.current) return;

--- a/src/hooks/useSaveSync.js
+++ b/src/hooks/useSaveSync.js
@@ -51,6 +51,8 @@ export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
   const doSave = useCallback(async () => {
     if (!isCognitoConfigured || !user) return;
     try {
+      // postSave 内部でも getAccessToken() を呼ぶが、ここでは beforeunload 用に
+      // tokenRef へ最新トークンをキャッシュする目的で別途取得している
       const token = await getAccessToken();
       tokenRef.current = token;
       await postSave(getGameStateRef.current());
@@ -67,29 +69,25 @@ export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
   }, [user, doSave]);
 
   // ページ離脱時に保存
-  // fetch keepalive を使うことでブラウザがページを閉じた後もリクエストを完遂する。
-  // getAccessToken() は非同期のため呼び出せないので、直前の定期セーブで更新した
-  // キャッシュトークンを使用する。
+  // sendBeacon は Authorization ヘッダーを付けられないため fetch + keepalive を使用。
+  // keepalive によりブラウザがページを閉じた後もリクエストを完遂する。
+  // getAccessToken() は非同期のため beforeunload 内では呼べないので、
+  // 直前の定期セーブで更新したキャッシュトークンを使用する。
   useEffect(() => {
     if (!isCognitoConfigured || !user) return;
     const handleBeforeUnload = () => {
       const token = tokenRef.current;
       if (!token) return;
       const body = JSON.stringify({ gameState: getGameStateRef.current() });
-      navigator.sendBeacon
-        ? navigator.sendBeacon(
-            '/api/save',
-            new Blob([body], { type: 'application/json' }),
-          )
-        : fetch('/api/save', {
-            method: 'POST',
-            keepalive: true,
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/json',
-            },
-            body,
-          });
+      fetch('/api/save', {
+        method: 'POST',
+        keepalive: true,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);

--- a/src/hooks/useSaveSync.js
+++ b/src/hooks/useSaveSync.js
@@ -1,0 +1,97 @@
+import { useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import { loadSave, postSave } from '../services/saveApi';
+import { isCognitoConfigured, getAccessToken } from '../services/cognitoAuth';
+
+const AUTO_SAVE_INTERVAL_MS = 60_000;
+
+/**
+ * ログイン時に自動ロード、定期的・ページ離脱時に自動セーブする。
+ * ユーザーはセーブ操作を一切意識しない。
+ *
+ * @param {object} options
+ * @param {object|null} options.user - AuthContext の user（未ログイン時は null）
+ * @param {() => object} options.getGameState - 現在のゲーム状態を返すコールバック
+ * @param {(gameState: object) => void} options.restoreGame - 保存済み状態を復元するコールバック
+ * @param {(data: object) => void} [options.onSaveLoaded] - セーブデータ取得後に呼ばれるコールバック
+ */
+export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
+  const hasLoadedRef = useRef(false);
+  // コールバック類は毎レンダーで再生成される可能性があるので ref 経由で最新を保持
+  const getGameStateRef = useRef(getGameState);
+  const onSaveLoadedRef = useRef(onSaveLoaded);
+  // beforeunload 時に同期的に使えるよう最新トークンをキャッシュする
+  const tokenRef = useRef(null);
+
+  // レンダー後に ref を同期（レンダー中の直接代入を避ける）
+  useLayoutEffect(() => {
+    getGameStateRef.current = getGameState;
+    onSaveLoadedRef.current = onSaveLoaded;
+  });
+
+  // ログイン時に自動ロード（1セッションに1回のみ）
+  useEffect(() => {
+    if (!isCognitoConfigured || !user || hasLoadedRef.current) return;
+    hasLoadedRef.current = true;
+
+    loadSave()
+      .then((data) => {
+        if (data.exists && data.gameState) {
+          restoreGame(data.gameState);
+        }
+        onSaveLoadedRef.current?.(data);
+      })
+      .catch((err) => console.error('Save load failed:', err));
+  }, [user, restoreGame]);
+
+  // ログアウト時にロード済みフラグをリセット
+  useEffect(() => {
+    if (!user) hasLoadedRef.current = false;
+  }, [user]);
+
+  const doSave = useCallback(async () => {
+    if (!isCognitoConfigured || !user) return;
+    try {
+      const token = await getAccessToken();
+      tokenRef.current = token;
+      await postSave(getGameStateRef.current());
+    } catch (err) {
+      console.error('Auto-save failed:', err);
+    }
+  }, [user]);
+
+  // 定期オートセーブ
+  useEffect(() => {
+    if (!isCognitoConfigured || !user) return;
+    const id = setInterval(doSave, AUTO_SAVE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [user, doSave]);
+
+  // ページ離脱時に保存
+  // fetch keepalive を使うことでブラウザがページを閉じた後もリクエストを完遂する。
+  // getAccessToken() は非同期のため呼び出せないので、直前の定期セーブで更新した
+  // キャッシュトークンを使用する。
+  useEffect(() => {
+    if (!isCognitoConfigured || !user) return;
+    const handleBeforeUnload = () => {
+      const token = tokenRef.current;
+      if (!token) return;
+      const body = JSON.stringify({ gameState: getGameStateRef.current() });
+      navigator.sendBeacon
+        ? navigator.sendBeacon(
+            '/api/save',
+            new Blob([body], { type: 'application/json' }),
+          )
+        : fetch('/api/save', {
+            method: 'POST',
+            keepalive: true,
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body,
+          });
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [user]);
+}

--- a/src/hooks/useUpgradeState.js
+++ b/src/hooks/useUpgradeState.js
@@ -210,6 +210,29 @@ export default function useUpgradeState() {
     setUnlockedTiers([BANANA_TIERS[0]]);
   }, []);
 
+  const restoreState = useCallback((gs) => {
+    setPurchased(new Set(gs.purchased ?? []));
+    setBananaPerClick(gs.bananaPerClick ?? 1);
+    setAutoSpawnRate(gs.autoSpawnRate ?? 0);
+    setGiantChance(gs.giantChance ?? 0);
+    const restoredTiers = gs.unlockedTierIds
+      ? BANANA_TIERS.filter((t) => gs.unlockedTierIds.includes(t.tier))
+      : [BANANA_TIERS[0]];
+    setUnlockedTiers(
+      restoredTiers.length > 0 ? restoredTiers : [BANANA_TIERS[0]],
+    );
+    setShopPurchases(gs.shopPurchases ?? {});
+    setTreeData({
+      level: gs.treeLevel ?? 0,
+      growth: gs.treeGrowth ?? 0,
+      banaCoins: gs.banaCoins ?? 0,
+      waterCount: gs.waterCount ?? 0,
+      chosenSkills: gs.chosenSkills ?? [],
+      chosenStages: gs.chosenStages ?? 0,
+      pendingChoice: null,
+    });
+  }, []);
+
   return {
     bananaPerClick,
     autoSpawnRate,
@@ -222,6 +245,7 @@ export default function useUpgradeState() {
     banaCoins: treeData.banaCoins,
     treeGrowth: treeData.growth,
     waterCount: treeData.waterCount,
+    treeChosenStages: treeData.chosenStages,
     waterTree,
     addBanaCoin,
     treeChosenSkills: treeData.chosenSkills,
@@ -233,5 +257,6 @@ export default function useUpgradeState() {
     cheatBanaCoins,
     adjustCoins,
     resetUpgrades,
+    restoreState,
   };
 }

--- a/src/services/cognitoAuth.js
+++ b/src/services/cognitoAuth.js
@@ -95,3 +95,17 @@ export function getCurrentUser() {
 
   return userPool.getCurrentUser();
 }
+
+export function getAccessToken() {
+  if (!userPool) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    const cognitoUser = userPool.getCurrentUser();
+    if (!cognitoUser) return resolve(null);
+
+    cognitoUser.getSession((err, session) => {
+      if (err || !session?.isValid()) return resolve(null);
+      resolve(session.getAccessToken().getJwtToken());
+    });
+  });
+}

--- a/src/services/saveApi.js
+++ b/src/services/saveApi.js
@@ -6,6 +6,7 @@ export const autoUserName = (sub) =>
 
 async function authFetch(path, options = {}) {
   const token = await getAccessToken();
+  if (!token) throw new Error('Not authenticated');
   return fetch(path, {
     ...options,
     headers: {

--- a/src/services/saveApi.js
+++ b/src/services/saveApi.js
@@ -1,0 +1,44 @@
+import { getAccessToken } from './cognitoAuth';
+
+// sub の先頭6文字からデフォルトのプレイヤー名を生成（バックエンドと同じロジック）
+export const autoUserName = (sub) =>
+  `Player-${sub.replace(/-/g, '').slice(0, 6)}`;
+
+async function authFetch(path, options = {}) {
+  const token = await getAccessToken();
+  return fetch(path, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+}
+
+export async function loadSave() {
+  const res = await authFetch('/api/save');
+  if (!res.ok) throw new Error(`loadSave failed: ${res.status}`);
+  return res.json();
+}
+
+export async function postSave(gameState) {
+  const res = await authFetch('/api/save', {
+    method: 'POST',
+    body: JSON.stringify({ gameState }),
+  });
+  if (!res.ok) throw new Error(`postSave failed: ${res.status}`);
+  return res.json();
+}
+
+export async function putProfile(userName) {
+  const res = await authFetch('/api/profile', {
+    method: 'PUT',
+    body: JSON.stringify({ userName }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `putProfile failed: ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## 概要

セーブ/ロード/リーダーボードのバックエンド API を Terraform で構築し、フロントエンドの自動セーブ/ロード・プロフィール設定機能を実装した。

## 関連イシュー

Closes #88

## 変更内容

### インフラ（Terraform）
- DynamoDB テーブルを追加（`pk=USER#<sub>`, `sk=SAVE#01`）、リーダーボード用 GSI 付き
- Lambda 関数を追加（Node.js 22、DynamoDB 最小権限 IAM ロール）
- API Gateway HTTP API を追加（Cognito JWT 認証、payload format 2.0）
  - `GET /api/save` / `POST /api/save` / `PUT /api/profile` / `GET /api/leaderboard`
- CloudFront に `/api/*` オリジン・ビヘイビアを追加
- CORS 設定、`dynamodb:UpdateItem` 権限、CI/CD ロールへの権限追加

### Lambda ハンドラー
- `POST /api/save`: `UpdateCommand` で `createdAt` を保護、`userName` を `if_not_exists` で自動生成（`Player-XXXXXX`）
- `PUT /api/profile`: ユーザー名変更（日本語対応・最大 20 文字・HTML タグ除去）、セーブ未作成時は 404
- `GET /api/leaderboard`: GSI でスコア降順上位 20 名を取得

### フロントエンド
- `cognitoAuth.js`: `getAccessToken()` を追加
- `saveApi.js` (新規): `loadSave` / `postSave` / `putProfile` API クライアント
- `useSaveSync.js` (新規): ログイン時自動ロード・60 秒定期セーブ・離脱時 `keepalive` セーブ
- `useUpgradeState.js`: `restoreState()` を追加してゲーム状態を復元可能に
- `ProfileModal.jsx` (新規): ユーザー名変更モーダル（文字数カウンター付き）
- `App.jsx`: `useSaveSync` 組み込み、右上にプロフィールボタンとログアウトボタンを配置

## 備考

- セーブ操作はすべて自動で行われ、ユーザーが意識する必要はない
- `userName` はデフォルトで `sub` から自動生成、プロフィール画面から変更可能
- ページ離脱時の保存は `sendBeacon` ではなく `fetch keepalive` を使用（Authorization ヘッダーが必要なため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **New Features**
  * 認証対応のクラウド保存/復元：ログイン時にセーブが自動で復元されます
  * プロフィール管理：プレイヤー名の設定・編集が可能なプロフィール画面を追加
  * ランキング表示：グローバルランキングで上位20名を確認可能
  * 自動セーブ＆終了時保存：定期自動保存とページ離脱時の保存（トークンを利用）に対応
<!-- end of auto-generated comment: release notes by coderabbit.ai -->