### PR TITLE
Fix viewport zoom persisting after login on mobile

### DIFF
--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -4,6 +4,16 @@ import LoginForm from './LoginForm';
 import SignupForm from './SignupForm';
 import ConfirmForm from './ConfirmForm';
 
+function resetViewportZoom() {
+  const viewport = document.querySelector('meta[name=viewport]');
+  if (!viewport) return;
+  const original = viewport.getAttribute('content');
+  viewport.setAttribute('content', original + ', maximum-scale=1');
+  requestAnimationFrame(() => {
+    viewport.setAttribute('content', original);
+  });
+}
+
 const BANANA_IMAGES = [
   'banana_ripe_01.png',
   'banana_ripe_02.png',
@@ -98,6 +108,7 @@ export default function AuthScreen() {
     setError('');
     try {
       await signIn(email, password);
+      resetViewportZoom();
     } catch (err) {
       setError(err.message || 'ログインに失敗しました');
     }

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -141,7 +141,7 @@ const styles = {
     padding: '12px 0',
     border: 'none',
     background: 'transparent',
-    fontSize: '15px',
+    fontSize: '16px',
     color: '#4a4a4a',
     outline: 'none',
     fontFamily: "'Outfit', sans-serif",

--- a/src/components/auth/SignupForm.jsx
+++ b/src/components/auth/SignupForm.jsx
@@ -223,7 +223,7 @@ const styles = {
     padding: '12px 0',
     border: 'none',
     background: 'transparent',
-    fontSize: '15px',
+    fontSize: '16px',
     color: '#4a4a4a',
     outline: 'none',
     fontFamily: "'Outfit', sans-serif",


### PR DESCRIPTION
## 概要
スマホブラウザでログイン画面をズームした状態でログインすると、ゲーム画面がそのズーム状態のまま表示されてしまう問題を修正する。

## 関連イシュー
Closes #94

## 変更内容
- `LoginForm.jsx` / `SignupForm.jsx`: 入力フィールドの `fontSize` を `15px` → `16px` に変更（iOS Safari は 16px 未満の入力にフォーカスすると自動ズームするため）
- `AuthScreen.jsx`: `resetViewportZoom()` 関数を追加し、ログイン成功後に viewport meta の `maximum-scale=1` を一時的にセットしてズームを強制リセットする

## 備考
`resetViewportZoom()` は `maximum-scale=1` を一時的にセットした後、`requestAnimationFrame` で元の値に戻すことで、ゲーム画面でのユーザーズーム操作は引き続き可能な状態を維持している。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サインイン成功時にビューポートズームの設定を調整する機能を追加しました。

* **スタイル**
  * ログインフォームとサインアップフォームの入力フィールドのフォントサイズを15pxから16pxに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->