### PR TITLE
Fix banana coins spawning on page reload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,6 +103,7 @@ function App() {
 
   // score の最新値を非同期コールバックから参照するための ref
   const scoreRef = useRef(score);
+  const prevTreeLevelRef = useRef(null);
   scoreRef.current = score;
 
   const getGameState = useCallback(
@@ -139,6 +140,9 @@ function App() {
 
   const restoreGame = useCallback(
     (gs) => {
+      // セーブ復元時のtreeLevelの変化をレベルアップと誤検知しないよう
+      // 復元前にrefを更新しておく
+      prevTreeLevelRef.current = gs.treeLevel ?? 0;
       restoreState(gs);
       setScore(gs.score ?? 0);
     },
@@ -186,7 +190,6 @@ function App() {
   }, []);
 
   // ツリーレベルアップ時にバナコインをスポーン（coinsPerLevelUp 個）
-  const prevTreeLevelRef = useRef(null);
   useEffect(() => {
     if (prevTreeLevelRef.current === null) {
       prevTreeLevelRef.current = treeLevel;


### PR DESCRIPTION
## 概要
ページリロード時にセーブデータが復元される際、ツリーレベルの変化がレベルアップと誤検知され、バナコインが意図せずスポーンしてしまうバグを修正した。

## 関連イシュー
Closes #96

## 変更内容
- `prevTreeLevelRef` の宣言を `restoreGame` コールバックより前に移動
- `restoreGame` 内でセーブデータの `treeLevel` を復元前に `prevTreeLevelRef.current` へ事前セットし、レベルアップ検知の誤発火を防止

## 備考
- 初期値 `0` → 保存済みレベル（例: `5`）への変化を「レベルアップ」と誤検知していたことが原因
- 通常のゲームプレイによるレベルアップ時のコインスポーンには影響なし