### PR TITLE
Show loading screen while save data is being fetched

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import ShopButton from './components/ui/ShopButton';
 import ShopModal from './components/ui/ShopModal';
 import UnlockedBananaTiers from './components/ui/UnlockedBananaTiers';
 import UpgradePanel from './components/ui/UpgradePanel';
+import LoadingScreen from './components/ui/LoadingScreen';
 
 import { TIER_COLORS } from './data/constants/tierColors';
 import { UPGRADE_GROUPS } from './data/constants/upgradeGroups';
@@ -149,7 +150,7 @@ function App() {
     [restoreState],
   );
 
-  useSaveSync({
+  const { isLoadingSave } = useSaveSync({
     user,
     getGameState,
     restoreGame,
@@ -439,6 +440,10 @@ function App() {
   // エフェクト適用後の値
   const effectiveRate = autoSpawnRate * effectiveAutoMultiplier;
   const effectiveGiantChance = isAllGiant ? 1 : giantChance;
+
+  if (isLoadingSave) {
+    return <LoadingScreen />;
+  }
 
   return (
     <main

--- a/src/components/auth/AuthGate.jsx
+++ b/src/components/auth/AuthGate.jsx
@@ -1,27 +1,12 @@
 import { useAuth } from '../../hooks/useAuth';
 import AuthScreen from './AuthScreen';
+import LoadingScreen from '../ui/LoadingScreen';
 
 export default function AuthGate({ children }) {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        aria-label="読み込み中"
-        style={styles.loading}
-      >
-        <div style={styles.loaderWrap}>
-          <img
-            src={`${import.meta.env.BASE_URL}banana_gold_01.png`}
-            alt=""
-            style={styles.loaderBanana}
-          />
-          <div style={styles.loaderDot} />
-        </div>
-      </div>
-    );
+    return <LoadingScreen />;
   }
 
   if (!isAuthenticated) {
@@ -30,33 +15,3 @@ export default function AuthGate({ children }) {
 
   return children;
 }
-
-const styles = {
-  loading: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: '100vh',
-    background:
-      'radial-gradient(ellipse at 50% 20%, #fff9e6 0%, #fcfaf5 50%, #f5efe0 100%)',
-  },
-  loaderWrap: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '16px',
-  },
-  loaderBanana: {
-    width: '48px',
-    height: 'auto',
-    animation: 'banana-float 1.5s ease-in-out infinite',
-    filter: 'drop-shadow(0 6px 12px rgba(212, 175, 55, 0.3))',
-  },
-  loaderDot: {
-    width: '24px',
-    height: '4px',
-    borderRadius: '2px',
-    background: 'rgba(212, 175, 55, 0.2)',
-    animation: 'loader-pulse 1.5s ease-in-out infinite',
-  },
-};

--- a/src/components/ui/LoadingScreen.jsx
+++ b/src/components/ui/LoadingScreen.jsx
@@ -1,0 +1,49 @@
+export default function LoadingScreen() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="読み込み中"
+      style={styles.loading}
+    >
+      <div style={styles.loaderWrap}>
+        <img
+          src={`${import.meta.env.BASE_URL}banana_gold_01.png`}
+          alt=""
+          style={styles.loaderBanana}
+        />
+        <div style={styles.loaderDot} />
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    background:
+      'radial-gradient(ellipse at 50% 20%, #fff9e6 0%, #fcfaf5 50%, #f5efe0 100%)',
+  },
+  loaderWrap: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '16px',
+  },
+  loaderBanana: {
+    width: '48px',
+    height: 'auto',
+    animation: 'banana-float 1.5s ease-in-out infinite',
+    filter: 'drop-shadow(0 6px 12px rgba(212, 175, 55, 0.3))',
+  },
+  loaderDot: {
+    width: '24px',
+    height: '4px',
+    borderRadius: '2px',
+    background: 'rgba(212, 175, 55, 0.2)',
+    animation: 'loader-pulse 1.5s ease-in-out infinite',
+  },
+};

--- a/src/hooks/useSaveSync.js
+++ b/src/hooks/useSaveSync.js
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useCallback,
+  useState,
+} from 'react';
 import { loadSave, postSave } from '../services/saveApi';
 import { isCognitoConfigured, getAccessToken } from '../services/cognitoAuth';
 
@@ -16,6 +22,9 @@ const AUTO_SAVE_INTERVAL_MS = 60_000;
  */
 export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
   const hasLoadedRef = useRef(false);
+  const [isLoadingSave, setIsLoadingSave] = useState(
+    () => isCognitoConfigured && !!user,
+  );
   // コールバック類は毎レンダーで再生成される可能性があるので ref 経由で最新を保持
   const getGameStateRef = useRef(getGameState);
   const onSaveLoadedRef = useRef(onSaveLoaded);
@@ -48,7 +57,8 @@ export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
         }
         onSaveLoadedRef.current?.(data);
       })
-      .catch((err) => console.error('Save load failed:', err));
+      .catch((err) => console.error('Save load failed:', err))
+      .finally(() => setIsLoadingSave(false));
   }, [user, restoreGame]);
 
   // ログアウト時にロード済みフラグをリセット
@@ -100,4 +110,6 @@ export function useSaveSync({ user, getGameState, restoreGame, onSaveLoaded }) {
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [user]);
+
+  return { isLoadingSave };
 }


### PR DESCRIPTION
## 概要
認証完了後、`GET /api/save` でセーブデータを取得する間ローディング画面を表示し、完了後にゲーム画面を表示する。

## 関連イシュー
Closes #98

## 変更内容
- `LoadingScreen` コンポーネントを新規作成（`src/components/ui/LoadingScreen.jsx`）
- `AuthGate` のインライン定義だったローディング UI を `LoadingScreen` に切り出し
- `useSaveSync` に `isLoadingSave` state を追加し、`loadSave()` 完了時に `false` にセット
- `App` で `isLoadingSave` が `true` の間 `<LoadingScreen />` を返すよう変更

## 備考
- Cognito 未設定時・未ログイン時は `isLoadingSave` が初期値 `false` のためローディングをスキップする
- `App` はログアウト時にアンマウントされるため、再ログイン時も初期値計算が再実行され正しく動作する