### PR TITLE
Reset all save data to initial state from debug panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useAuth } from './hooks/useAuth';
 import { useSaveSync } from './hooks/useSaveSync';
-import { autoUserName } from './services/saveApi';
+import { autoUserName, postSave } from './services/saveApi';
 import ProfileModal from './components/auth/ProfileModal';
 import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
@@ -18,6 +18,7 @@ import UpgradePanel from './components/ui/UpgradePanel';
 import LoadingScreen from './components/ui/LoadingScreen';
 
 import { TIER_COLORS } from './data/constants/tierColors';
+import { BANANA_TIERS } from './data/constants/bananaTiers';
 import { UPGRADE_GROUPS } from './data/constants/upgradeGroups';
 import { PANEL_HEIGHT } from './data/constants/layout';
 import useUpgradeState from './hooks/useUpgradeState';
@@ -377,6 +378,31 @@ function App() {
   const handleAdjustScore = useCallback((delta) => {
     setScore((s) => Math.max(0, s + delta));
   }, []);
+
+  const handleResetAll = useCallback(async () => {
+    resetUpgrades();
+    setScore(0);
+    const initialState = {
+      score: 0,
+      purchased: [],
+      bananaPerClick: 1,
+      autoSpawnRate: 0,
+      giantChance: 0,
+      unlockedTierIds: [BANANA_TIERS[0].tier],
+      treeLevel: 0,
+      treeGrowth: 0,
+      banaCoins: 0,
+      waterCount: 0,
+      chosenSkills: [],
+      chosenStages: 0,
+      shopPurchases: {},
+    };
+    try {
+      await postSave(initialState);
+    } catch (err) {
+      console.error('Reset save failed:', err);
+    }
+  }, [resetUpgrades]);
 
   const handleWaterTree = useCallback(() => {
     const cost = waterTree(
@@ -879,7 +905,7 @@ function App() {
         onCoinCollected={handleCoinCollected}
         shopPurchases={shopPurchases}
         devMode={devMode}
-        onResetUpgrades={resetUpgrades}
+        onResetUpgrades={handleResetAll}
         onAdjustScore={handleAdjustScore}
         onAdjustCoins={adjustCoins}
         isOneKind={isOneKind}

--- a/src/hooks/useUpgradeState.js
+++ b/src/hooks/useUpgradeState.js
@@ -208,6 +208,16 @@ export default function useUpgradeState() {
     setAutoSpawnRate(0);
     setGiantChance(0);
     setUnlockedTiers([BANANA_TIERS[0]]);
+    setShopPurchases({});
+    setTreeData({
+      level: 0,
+      growth: 0,
+      banaCoins: 0,
+      waterCount: 0,
+      chosenSkills: [],
+      chosenStages: 0,
+      pendingChoice: null,
+    });
   }, []);
 
   const restoreState = useCallback((gs) => {


### PR DESCRIPTION
## 概要
デバッグパネルの「リセット」ボタンを押すと、DynamoDB のセーブデータを初期値で上書きし、メモリ上のすべてのゲーム状態も初期化する。

## 関連イシュー
Closes #101

## 変更内容
- `useUpgradeState.js`: `resetUpgrades` でアップグレードに加え `shopPurchases` と `treeData` も初期化するよう拡張
- `App.jsx`: `handleResetAll` を新設し、メモリ初期化（`resetUpgrades` + `setScore(0)`）と `postSave(初期状態)` による DynamoDB 書き込みをまとめて実行
- `App.jsx`: `onResetUpgrades` の渡し先を `resetUpgrades` から `handleResetAll` に変更

## 備考
リロード後も初期状態が維持されることを手動で確認すること。