### PR TITLE
Fix profile button overlapping logout button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -490,7 +490,10 @@ function App() {
             right: 12,
             zIndex: 50,
             display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
             gap: 6,
+            maxWidth: 'calc(100vw - 24px)',
           }}
           onClick={(e) => e.stopPropagation()}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -960,11 +960,6 @@ body {
     font-size: 0.6rem !important;
     padding: 3px 10px !important;
   }
-
-  .logout-button {
-    top: 8px !important;
-    right: 12px !important;
-  }
 }
 
 /* ── Responsive: very small screens (global classes only) ── */
@@ -1026,8 +1021,6 @@ body {
   }
 
   .logout-button {
-    top: 4px !important;
-    right: 8px !important;
     font-size: 9px !important;
     padding: 3px 8px !important;
   }
@@ -1035,10 +1028,6 @@ body {
 
 /* ── Logout button ── */
 .logout-button {
-  position: fixed;
-  top: 12px;
-  right: 24px;
-  z-index: 1001;
   display: flex;
   align-items: center;
   gap: 5px;


### PR DESCRIPTION
## 概要
`.logout-button` に `position: fixed` が付いていたため、プロフィールボタンとログアウトボタンが同じ座標に重なって表示されていた。親の `div` が既に `position: fixed` + `flex` でレイアウトを管理しているため、`.logout-button` 側の固定位置指定を削除して修正した。

## 関連イシュー
Closes #103

## 変更内容
- `src/index.css`: `.logout-button` から `position: fixed`・`top`・`right`・`z-index` を削除
- `src/index.css`: モバイル用メディアクエリの `.logout-button` の `top`・`right` オーバーライドを削除
- `src/App.jsx`: ボタン群の親 `div` に `flexWrap: 'wrap'`・`justifyContent: 'flex-end'`・`maxWidth: 'calc(100vw - 24px)'` を追加し、スマホ画面でもレイアウトが崩れないよう対応

## 備考
特記事項なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル

* ボタンコンテナのレイアウトを改善し、複数行への折り返しに対応しました
* ビューポート幅の制限により、画面サイズに関わらず適切に表示されるようになりました
* 認証ボタンの配置がより柔軟で応答性の高いものになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->