### PR TITLE
Integrate frontend with save/load and leaderboard API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { useAuth } from './hooks/useAuth';
 import { useSaveSync } from './hooks/useSaveSync';
 import { autoUserName, postSave } from './services/saveApi';
 import ProfileModal from './components/auth/ProfileModal';
+import LeaderboardModal from './components/ui/LeaderboardModal';
 import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
 import FeverBurst from './components/ui/FeverBurst';
@@ -176,6 +177,7 @@ function App() {
   const [devMode, setDevMode] = useState(false);
   const [isShopOpen, setIsShopOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
   const [userName, setUserName] = useState(null);
   const [floatingCoins, setFloatingCoins] = useState([]);
 
@@ -499,6 +501,28 @@ function App() {
         >
           <button
             className="logout-button"
+            onClick={() => setIsLeaderboardOpen(true)}
+            aria-label="リーダーボード"
+            title="リーダーボード"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+              <polyline points="17 6 23 6 23 12" />
+            </svg>
+            <span>Ranking</span>
+          </button>
+          <button
+            className="logout-button"
             onClick={() => setIsProfileOpen(true)}
             aria-label="プロフィール設定"
             title={userName ?? ''}
@@ -559,6 +583,12 @@ function App() {
           userName={userName}
           onClose={() => setIsProfileOpen(false)}
           onSaved={(newName) => setUserName(newName)}
+        />
+      )}
+      {isLeaderboardOpen && (
+        <LeaderboardModal
+          currentUserName={userName}
+          onClose={() => setIsLeaderboardOpen(false)}
         />
       )}
       <ScoreDisplay

--- a/src/components/ui/LeaderboardModal.jsx
+++ b/src/components/ui/LeaderboardModal.jsx
@@ -1,0 +1,209 @@
+import { useState, useEffect } from 'react';
+import { getLeaderboard } from '../../services/saveApi';
+
+export default function LeaderboardModal({ currentUserName, onClose }) {
+  const [entries, setEntries] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getLeaderboard()
+      .then((data) => setEntries(data.entries ?? []))
+      .catch((err) => setError(err.message ?? '取得に失敗しました'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="リーダーボード"
+      style={styles.overlay}
+      onClick={onClose}
+    >
+      <div
+        className="glass-panel"
+        style={styles.panel}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={styles.header}>
+          <span style={styles.title}>🏆 リーダーボード</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            style={styles.closeButton}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div style={styles.body}>
+          {isLoading && <p style={styles.message}>読み込み中...</p>}
+          {error && <p style={styles.errorMessage}>{error}</p>}
+          {!isLoading && !error && entries.length === 0 && (
+            <p style={styles.message}>まだスコアが登録されていません</p>
+          )}
+          {!isLoading && !error && entries.length > 0 && (
+            <ol style={styles.list}>
+              {entries.map((entry) => {
+                const isMe = entry.userName === currentUserName;
+                return (
+                  <li key={entry.rank} style={styles.entry(entry.rank, isMe)}>
+                    <span style={styles.rank(entry.rank)}>
+                      {entry.rank === 1
+                        ? '🥇'
+                        : entry.rank === 2
+                          ? '🥈'
+                          : entry.rank === 3
+                            ? '🥉'
+                            : entry.rank}
+                    </span>
+                    <span style={styles.userName}>
+                      {entry.userName}
+                      {isMe && <span style={styles.meBadge}>YOU</span>}
+                    </span>
+                    <span style={styles.score}>
+                      {entry.score.toLocaleString()}
+                    </span>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  overlay: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 100,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(0,0,0,0.45)',
+    backdropFilter: 'blur(4px)',
+    WebkitBackdropFilter: 'blur(4px)',
+  },
+  panel: {
+    width: 'min(420px, 92vw)',
+    maxHeight: '80vh',
+    borderRadius: '28px',
+    padding: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    background: 'rgba(255,255,255,0.94)',
+    border: '1px solid var(--accent-gold-soft)',
+    boxShadow: '0 24px 64px rgba(0,0,0,0.18)',
+    animation: 'slideInModal 0.25s cubic-bezier(0.16, 1, 0.3, 1)',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexShrink: 0,
+  },
+  title: {
+    fontSize: '18px',
+    fontWeight: 800,
+    color: '#3a3020',
+    letterSpacing: '0.02em',
+  },
+  closeButton: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '14px',
+    color: '#8a7a60',
+    padding: '4px 8px',
+    borderRadius: '8px',
+    transition: 'background 0.15s',
+    fontFamily: 'inherit',
+  },
+  body: {
+    overflowY: 'auto',
+    flex: 1,
+    minHeight: 0,
+  },
+  message: {
+    textAlign: 'center',
+    color: '#8a7a60',
+    fontSize: '14px',
+    padding: '24px 0',
+    margin: 0,
+  },
+  errorMessage: {
+    textAlign: 'center',
+    color: '#b91c1c',
+    fontSize: '13px',
+    padding: '24px 0',
+    margin: 0,
+  },
+  list: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+  },
+  entry: (rank, isMe) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    padding: '10px 14px',
+    borderRadius: '12px',
+    background: isMe
+      ? 'rgba(212,175,55,0.12)'
+      : rank <= 3
+        ? 'rgba(212,175,55,0.06)'
+        : 'rgba(0,0,0,0.02)',
+    border: isMe
+      ? '1.5px solid rgba(212,175,55,0.35)'
+      : '1.5px solid transparent',
+    fontWeight: isMe ? 700 : 500,
+  }),
+  rank: (rank) => ({
+    minWidth: 28,
+    textAlign: 'center',
+    fontSize: rank <= 3 ? '1.2rem' : '0.85rem',
+    fontWeight: 700,
+    color: '#8a7a60',
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  }),
+  userName: {
+    flex: 1,
+    fontSize: '14px',
+    color: '#3a3020',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+  },
+  meBadge: {
+    fontSize: '9px',
+    fontWeight: 800,
+    color: '#b8860b',
+    background: 'rgba(212,175,55,0.2)',
+    border: '1px solid rgba(212,175,55,0.4)',
+    borderRadius: '4px',
+    padding: '1px 5px',
+    letterSpacing: '0.05em',
+    flexShrink: 0,
+  },
+  score: {
+    fontSize: '14px',
+    fontWeight: 700,
+    color: '#5a4a30',
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  },
+};

--- a/src/components/ui/LeaderboardModal.jsx
+++ b/src/components/ui/LeaderboardModal.jsx
@@ -49,7 +49,10 @@ export default function LeaderboardModal({ currentUserName, onClose }) {
               {entries.map((entry) => {
                 const isMe = entry.userName === currentUserName;
                 return (
-                  <li key={entry.rank} style={styles.entry(entry.rank, isMe)}>
+                  <li
+                    key={entry.userName}
+                    style={styles.entry(entry.rank, isMe)}
+                  >
                     <span style={styles.rank(entry.rank)}>
                       {entry.rank === 1
                         ? '🥇'

--- a/src/services/saveApi.js
+++ b/src/services/saveApi.js
@@ -43,3 +43,9 @@ export async function putProfile(userName) {
   }
   return res.json();
 }
+
+export async function getLeaderboard() {
+  const res = await authFetch('/api/leaderboard');
+  if (!res.ok) throw new Error(`getLeaderboard failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## 概要

フロントエンドからバックエンド API を呼び出し、リーダーボード表示機能を実装する。セーブ/ロード・プロフィール取得は #88 までに実装済みのため、本PRではリーダーボード機能を追加する。

## 関連イシュー

Closes #89

## 変更内容

- `src/services/saveApi.js`: `getLeaderboard()` 関数を追加（`GET /api/leaderboard` を JWT 付きで呼び出し）
- `src/components/ui/LeaderboardModal.jsx`: リーダーボードモーダルを新規作成
  - モーダル表示時に自動フェッチ
  - ローディング / エラー / 空 / データありの4状態を表示
  - 1〜3位は絵文字メダル表示
  - 自分のエントリーをゴールドハイライト + YOU バッジで強調
- `src/App.jsx`: Ranking ボタンとリーダーボードモーダルを組み込み

## 備考

- ローカル開発環境（`npm run dev`）では `/api/*` の相対パスが解決できないため API 呼び出しは失敗するが、CloudFront 経由の本番環境では正常動作する