### PR TITLE
Split App.jsx into focused modules

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,17 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import useLatestRef from './hooks/useLatestRef';
 import { useAuth } from './hooks/useAuth';
 import { useSaveSync } from './hooks/useSaveSync';
 import { autoUserName, postSave } from './services/saveApi';
-import ProfileModal from './components/auth/ProfileModal';
-import LeaderboardModal from './components/ui/LeaderboardModal';
+import { computeTreeSkillBonuses } from './services/treeSkillBonuses';
+import AuthToolbar from './components/auth/AuthToolbar';
 import BananaWorld from './components/BananaWorld';
 import ClickRipple from './components/ui/ClickRipple';
 import FeverBurst from './components/ui/FeverBurst';
 import SpawnFlash from './components/ui/SpawnFlash';
 import CoinSpawnFlash from './components/ui/CoinSpawnFlash';
 import FloatingScoreText from './components/ui/FloatingScoreText';
+import FloatingCoinList from './components/ui/FloatingCoinList';
 import ScoreDisplay from './components/ui/ScoreDisplay';
 import BananaTree from './components/ui/BananaTree';
 import ShopButton from './components/ui/ShopButton';
@@ -17,6 +19,7 @@ import ShopModal from './components/ui/ShopModal';
 import UnlockedBananaTiers from './components/ui/UnlockedBananaTiers';
 import UpgradePanel from './components/ui/UpgradePanel';
 import LoadingScreen from './components/ui/LoadingScreen';
+import ActiveEffectStatusBars from './components/ui/ActiveEffectStatusBars';
 
 import { TIER_COLORS } from './data/constants/tierColors';
 import { BANANA_TIERS } from './data/constants/bananaTiers';
@@ -24,6 +27,10 @@ import { UPGRADE_GROUPS } from './data/constants/upgradeGroups';
 import { PANEL_HEIGHT } from './data/constants/layout';
 import useUpgradeState from './hooks/useUpgradeState';
 import useActiveEffects from './hooks/useActiveEffects';
+import useDevMode from './hooks/useDevMode';
+import useScoreTracking from './hooks/useScoreTracking';
+import useVisualEffects from './hooks/useVisualEffects';
+import useTreeLevelUpCoins from './hooks/useTreeLevelUpCoins';
 
 // oneバナナ着地時にスポーンする「1種類」を決定する
 const pickOneKindSelection = (unlockedTiers) => {
@@ -31,16 +38,8 @@ const pickOneKindSelection = (unlockedTiers) => {
   return { type: 'tier', tier };
 };
 
-let _textId = 0;
-
-const MAX_FLOATING_TEXTS = 15;
-const MAX_CLICK_EFFECTS = 5;
-const MAX_SPAWN_FLASHES = 3;
-const MAX_FEVER_BURSTS = 3;
-
 function App() {
   const { signOut, user, authEnabled } = useAuth();
-  const [score, setScore] = useState(0);
   const {
     bananaPerClick,
     autoSpawnRate,
@@ -80,34 +79,50 @@ function App() {
     oneKindSelection,
   } = useActiveEffects();
 
-  // 選択済みスキルのボーナスを集計
-  const treeWaterBonus = treeChosenSkills.reduce(
-    (sum, s) => sum + (s.waterBoost ?? 0),
-    0,
-  );
-  const treeWaterCostDiscount = Math.min(
-    treeChosenSkills.reduce((sum, s) => sum + (s.waterCostDiscount ?? 0), 0),
-    0.9, // 最大90%割引
-  );
-  // レベルアップ時コイン数（ref 経由で stale closure を回避）
-  const coinsPerLevelUpRef = useRef(1);
-  coinsPerLevelUpRef.current =
-    1 + treeChosenSkills.reduce((sum, s) => sum + (s.coinsPerLevelUp ?? 0), 0);
-  // 特殊バナナ出現率アップボーナス
-  const treeMutationRateBonus = treeChosenSkills.reduce(
-    (sum, s) => sum + (s.mutationRateBonus ?? 0),
-    0,
-  );
-  // タップ時大量生成ボーナス確率
-  const treeCriticalClickChance = treeChosenSkills.reduce(
-    (sum, s) => sum + (s.criticalClickChance ?? 0),
-    0,
-  );
+  const {
+    waterBoost: treeWaterBonus,
+    waterCostDiscount: treeWaterCostDiscount,
+    coinsPerLevelUp,
+    mutationRateBonus: treeMutationRateBonus,
+    criticalClickChance: treeCriticalClickChance,
+  } = computeTreeSkillBonuses(treeChosenSkills);
+
+  const devMode = useDevMode();
+
+  const {
+    score,
+    setScore,
+    scoreBump,
+    perSecond,
+    floatingTexts,
+    handleScore,
+    adjustScore: handleAdjustScore,
+  } = useScoreTracking();
+
+  const {
+    clickEffects,
+    feverBursts,
+    spawnFlashes,
+    coinFlashes,
+    floatingCoins,
+    triggerClickRipple,
+    triggerSpawnFlash,
+    triggerFeverBurst,
+    spawnCoinFlashes,
+    spawnFloatingCoin,
+  } = useVisualEffects();
+
+  const bananaWorldRef = useRef(null);
+
+  const { primeTreeLevel } = useTreeLevelUpCoins({
+    treeLevel,
+    coinsPerLevelUp,
+    spawnPhysicsCoin: (x) => bananaWorldRef.current?.spawnCoin(x),
+    spawnCoinFlashes,
+  });
 
   // score の最新値を非同期コールバックから参照するための ref
-  const scoreRef = useRef(score);
-  const prevTreeLevelRef = useRef(null);
-  scoreRef.current = score;
+  const scoreRef = useLatestRef(score);
 
   const getGameState = useCallback(
     () => ({
@@ -126,6 +141,7 @@ function App() {
       shopPurchases,
     }),
     [
+      scoreRef,
       purchased,
       bananaPerClick,
       autoSpawnRate,
@@ -143,14 +159,16 @@ function App() {
 
   const restoreGame = useCallback(
     (gs) => {
-      // セーブ復元時のtreeLevelの変化をレベルアップと誤検知しないよう
-      // 復元前にrefを更新しておく
-      prevTreeLevelRef.current = gs.treeLevel ?? 0;
+      // セーブ復元時の treeLevel 変化をレベルアップと誤検知しないよう
+      // 復元前に prev を合わせておく
+      primeTreeLevel(gs.treeLevel ?? 0);
       restoreState(gs);
       setScore(gs.score ?? 0);
     },
-    [restoreState],
+    [restoreState, setScore, primeTreeLevel],
   );
+
+  const [userName, setUserName] = useState(null);
 
   const { isLoadingSave } = useSaveSync({
     user,
@@ -165,180 +183,22 @@ function App() {
     },
   });
 
-  const bananaWorldRef = useRef(null);
-
-  const [floatingTexts, setFloatingTexts] = useState([]);
-  const [clickEffects, setClickEffects] = useState([]);
-  const [feverBursts, setFeverBursts] = useState([]);
-  const [spawnFlashes, setSpawnFlashes] = useState([]);
-  const [coinFlashes, setCoinFlashes] = useState([]);
-  const [scoreBump, setScoreBump] = useState(false);
-  const [perSecond, setPerSecond] = useState(0);
-  const [devMode, setDevMode] = useState(false);
-  const [isShopOpen, setIsShopOpen] = useState(false);
-  const [isProfileOpen, setIsProfileOpen] = useState(false);
-  const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
-  const [userName, setUserName] = useState(null);
-  const [floatingCoins, setFloatingCoins] = useState([]);
-
-  // 開発者モード: Ctrl+Shift+D で切り替え
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
-        e.preventDefault();
-        setDevMode((prev) => !prev);
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
-
-  // ツリーレベルアップ時にバナコインをスポーン（coinsPerLevelUp 個）
-  useEffect(() => {
-    if (prevTreeLevelRef.current === null) {
-      prevTreeLevelRef.current = treeLevel;
-      return;
-    }
-    if (treeLevel > prevTreeLevelRef.current) {
-      const count = coinsPerLevelUpRef.current;
-      const newFlashes = [];
-      for (let i = 0; i < count; i++) {
-        const x = 80 + Math.random() * (window.innerWidth - 160);
-        bananaWorldRef.current?.spawnCoin(x);
-        newFlashes.push({ id: ++_textId, x });
-      }
-      setCoinFlashes((prev) => [...prev, ...newFlashes]);
-      const flashIds = new Set(newFlashes.map((f) => f.id));
-      setTimeout(
-        () => setCoinFlashes((prev) => prev.filter((f) => !flashIds.has(f.id))),
-        1800,
-      );
-    }
-    prevTreeLevelRef.current = treeLevel;
-  }, [treeLevel]);
-
   const handleCoinCollected = useCallback(
     (x) => {
       addBanaCoin();
-      const id = ++_textId;
-      const clampedX = Math.max(
-        60,
-        Math.min(window.innerWidth - 60, x ?? window.innerWidth / 2),
-      );
-      setFloatingCoins((prev) => [...prev, { id, x: clampedX }]);
-      setTimeout(
-        () => setFloatingCoins((prev) => prev.filter((c) => c.id !== id)),
-        1200,
-      );
+      spawnFloatingCoin(x);
     },
-    [addBanaCoin],
+    [addBanaCoin, spawnFloatingCoin],
   );
 
-  // 実測ローリング平均（5秒間の実スコア履歴から計算）
-  const scoreHistoryRef = useRef([]);
-  useEffect(() => {
-    const id = setInterval(() => {
-      const now = Date.now();
-      const cutoff = now - 5000;
-      scoreHistoryRef.current = scoreHistoryRef.current.filter(
-        (e) => e.time > cutoff,
-      );
-      const total = scoreHistoryRef.current.reduce((s, e) => s + e.score, 0);
-      setPerSecond(Math.round(total / 5));
-    }, 500);
-    return () => clearInterval(id);
-  }, []);
-
-  // スコアテキストをフレーム単位でバッチ集約し、DOM要素数を削減
-  const scoreBatchRef = useRef([]);
-  const scoreRafRef = useRef(0);
-
-  const handleScore = useCallback((scoreItems) => {
-    const total = scoreItems.reduce((sum, item) => sum + item.score, 0);
-    setScore((s) => s + total);
-    scoreHistoryRef.current.push({ time: Date.now(), score: total });
-    setScoreBump(true);
-    setTimeout(() => setScoreBump(false), 300);
-
-    // バッチに追加し、次フレームでまとめてDOM生成
-    scoreBatchRef.current.push(...scoreItems);
-    if (!scoreRafRef.current) {
-      scoreRafRef.current = requestAnimationFrame(() => {
-        scoreRafRef.current = 0;
-        const batch = scoreBatchRef.current;
-        scoreBatchRef.current = [];
-        if (batch.length === 0) return;
-
-        // 同フレーム内のスコアをX位置で近いもの同士にまとめる（最大8個）
-        const merged = [];
-        const sorted = batch.sort((a, b) => a.x - b.x);
-        let current = { ...sorted[0] };
-        for (let i = 1; i < sorted.length; i++) {
-          const item = sorted[i];
-          if (Math.abs(item.x - current.x) < 60 && item.tier === current.tier) {
-            current.score += item.score;
-          } else {
-            merged.push(current);
-            current = { ...item };
-          }
-        }
-        merged.push(current);
-        // 最大8個に制限
-        const limited = merged.length > 8 ? merged.slice(0, 8) : merged;
-
-        const newTexts = limited.map((item) => ({
-          id: ++_textId,
-          value: item.score,
-          tier: item.tier,
-          x: Math.max(40, Math.min(window.innerWidth - 40, item.x)),
-        }));
-
-        setFloatingTexts((prev) => {
-          const combined = [...prev, ...newTexts];
-          // 同時表示上限を超えた分は古いものから削除
-          return combined.length > MAX_FLOATING_TEXTS
-            ? combined.slice(combined.length - MAX_FLOATING_TEXTS)
-            : combined;
-        });
-        setTimeout(() => {
-          const ids = new Set(newTexts.map((t) => t.id));
-          setFloatingTexts((prev) => prev.filter((t) => !ids.has(t.id)));
-        }, 1200);
-      });
-    }
-  }, []);
-
-  const handleClick = useCallback((e) => {
-    const id = ++_textId;
-    setClickEffects((prev) => {
-      const next = [...prev, { id, x: e.clientX, y: e.clientY }];
-      return next.length > MAX_CLICK_EFFECTS
-        ? next.slice(next.length - MAX_CLICK_EFFECTS)
-        : next;
-    });
-    setTimeout(
-      () => setClickEffects((prev) => prev.filter((ef) => ef.id !== id)),
-      600,
-    );
-  }, []);
-
-  // 特殊バナナがスポーンしたときのエフェクト
-  const handleSpecialSpawn = useCallback((x, itemId) => {
-    const id = ++_textId;
-    setSpawnFlashes((prev) => {
-      const next = [...prev, { id, x, itemId }];
-      return next.length > MAX_SPAWN_FLASHES
-        ? next.slice(next.length - MAX_SPAWN_FLASHES)
-        : next;
-    });
-    setTimeout(
-      () => setSpawnFlashes((prev) => prev.filter((f) => f.id !== id)),
-      1200,
-    );
-  }, []);
+  const handleClick = useCallback(
+    (e) => {
+      triggerClickRipple(e.clientX, e.clientY);
+    },
+    [triggerClickRipple],
+  );
 
   // 特殊バナナが着地したときの処理
-  // pos: { x, y } — 着地位置（バースト表示に使用）
   const handleEffect = useCallback(
     (itemId, pos) => {
       const count = shopPurchases[itemId] ?? 1;
@@ -348,22 +208,11 @@ function App() {
       } else {
         triggerEffect(itemId, count);
       }
-
       if (pos) {
-        const burstId = ++_textId;
-        setFeverBursts((prev) => {
-          const next = [...prev, { id: burstId, x: pos.x, y: pos.y, itemId }];
-          return next.length > MAX_FEVER_BURSTS
-            ? next.slice(next.length - MAX_FEVER_BURSTS)
-            : next;
-        });
-        setTimeout(
-          () => setFeverBursts((prev) => prev.filter((b) => b.id !== burstId)),
-          1100,
-        );
+        triggerFeverBurst(pos.x, pos.y, itemId);
       }
     },
-    [shopPurchases, unlockedTiers, triggerEffect],
+    [shopPurchases, unlockedTiers, triggerEffect, triggerFeverBurst],
   );
 
   const handleBuyUpgrade = useCallback(
@@ -374,12 +223,8 @@ function App() {
         setScore((currentScore) => currentScore - upgrade.cost);
       }
     },
-    [buyUpgrade, score, devMode],
+    [buyUpgrade, score, devMode, setScore],
   );
-
-  const handleAdjustScore = useCallback((delta) => {
-    setScore((s) => Math.max(0, s + delta));
-  }, []);
 
   const handleResetAll = useCallback(async () => {
     resetUpgrades();
@@ -404,7 +249,7 @@ function App() {
     } catch (err) {
       console.error('Reset save failed:', err);
     }
-  }, [resetUpgrades]);
+  }, [resetUpgrades, setScore]);
 
   const handleWaterTree = useCallback(() => {
     const cost = waterTree(
@@ -416,58 +261,22 @@ function App() {
     if (cost !== false && !devMode) {
       setScore((currentScore) => currentScore - cost);
     }
-  }, [waterTree, score, devMode, treeWaterBonus, treeWaterCostDiscount]);
+  }, [
+    waterTree,
+    score,
+    devMode,
+    treeWaterBonus,
+    treeWaterCostDiscount,
+    setScore,
+  ]);
 
   const scoreColor = (tier) => TIER_COLORS[tier - 1] ?? '#555';
-
-  // フィーバー残り秒数と進捗
-  const feverRemaining = isFever
-    ? Math.max(0, Math.ceil((feverEndTime - Date.now()) / 1000))
-    : 0;
-  const feverPercent =
-    isFever && feverDuration > 0
-      ? Math.max(
-          0,
-          Math.min(
-            100,
-            ((feverEndTime - Date.now()) / (feverDuration * 1000)) * 100,
-          ),
-        )
-      : 0;
-
-  // oneKind 残り秒数と進捗
-  const oneKindRemaining = isOneKind
-    ? Math.max(0, Math.ceil((oneKindEndTime - Date.now()) / 1000))
-    : 0;
-  const oneKindPercent =
-    isOneKind && oneKindDuration > 0
-      ? Math.max(
-          0,
-          Math.min(
-            100,
-            ((oneKindEndTime - Date.now()) / (oneKindDuration * 1000)) * 100,
-          ),
-        )
-      : 0;
-
-  // allGiant 残り秒数と進捗
-  const allGiantRemaining = isAllGiant
-    ? Math.max(0, Math.ceil((allGiantEndTime - Date.now()) / 1000))
-    : 0;
-  const allGiantPercent =
-    isAllGiant && allGiantDuration > 0
-      ? Math.max(
-          0,
-          Math.min(
-            100,
-            ((allGiantEndTime - Date.now()) / (allGiantDuration * 1000)) * 100,
-          ),
-        )
-      : 0;
 
   // エフェクト適用後の値
   const effectiveRate = autoSpawnRate * effectiveAutoMultiplier;
   const effectiveGiantChance = isAllGiant ? 1 : giantChance;
+
+  const [isShopOpen, setIsShopOpen] = useState(false);
 
   if (isLoadingSave) {
     return <LoadingScreen />;
@@ -484,113 +293,13 @@ function App() {
       }}
       onClick={handleClick}
     >
-      {authEnabled && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 12,
-            right: 12,
-            zIndex: 50,
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'flex-end',
-            gap: 6,
-            maxWidth: 'calc(100vw - 24px)',
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <button
-            className="logout-button"
-            onClick={() => setIsLeaderboardOpen(true)}
-            aria-label="リーダーボード"
-            title="リーダーボード"
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
-              <polyline points="17 6 23 6 23 12" />
-            </svg>
-            <span>Ranking</span>
-          </button>
-          <button
-            className="logout-button"
-            onClick={() => setIsProfileOpen(true)}
-            aria-label="プロフィール設定"
-            title={userName ?? ''}
-            style={{ gap: 5 }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="12" cy="8" r="4" />
-              <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
-            </svg>
-            <span
-              style={{
-                maxWidth: 80,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {userName ?? '…'}
-            </span>
-          </button>
-          <button
-            className="logout-button"
-            onClick={signOut}
-            aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
-            title={user?.email}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-              <polyline points="16 17 21 12 16 7" />
-              <line x1="21" y1="12" x2="9" y2="12" />
-            </svg>
-            <span>Logout</span>
-          </button>
-        </div>
-      )}
-      {isProfileOpen && (
-        <ProfileModal
-          userName={userName}
-          onClose={() => setIsProfileOpen(false)}
-          onSaved={(newName) => setUserName(newName)}
-        />
-      )}
-      {isLeaderboardOpen && (
-        <LeaderboardModal
-          currentUserName={userName}
-          onClose={() => setIsLeaderboardOpen(false)}
-        />
-      )}
+      <AuthToolbar
+        authEnabled={authEnabled}
+        user={user}
+        userName={userName}
+        onUserNameChange={setUserName}
+        signOut={signOut}
+      />
       <ScoreDisplay
         score={score}
         perSecond={perSecond}
@@ -620,227 +329,17 @@ function App() {
         />
       )}
 
-      {/* フィーバー：上部カウントダウンバー + 中央ラベル */}
-      {isFever && (
-        <>
-          {/* 画面最上部の光る帯 */}
-          <div
-            style={{
-              position: 'fixed',
-              top: 0,
-              left: 0,
-              right: 0,
-              height: 5,
-              zIndex: 200,
-              background: 'rgba(0,0,0,0.06)',
-              pointerEvents: 'none',
-            }}
-          >
-            <div
-              style={{
-                height: '100%',
-                width: `${feverPercent}%`,
-                background: 'linear-gradient(90deg, #ff6b35, #ffd700, #ff9f00)',
-                backgroundSize: '200% 100%',
-                boxShadow:
-                  '0 0 12px rgba(255,107,53,0.8), 0 0 4px rgba(255,215,0,0.6)',
-                borderRadius: '0 3px 3px 0',
-                transition: 'width 0.5s linear',
-                animation: 'feverBarShimmer 2s linear infinite',
-              }}
-            />
-          </div>
-
-          {/* 中央フローティングラベル */}
-          <div
-            className="effect-status-label"
-            role="status"
-            aria-label={`ぬいバナナフィーバー 残り${feverRemaining}秒`}
-            style={{
-              position: 'fixed',
-              top: 10,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              zIndex: 201,
-              pointerEvents: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              background: 'rgba(255, 100, 30, 0.12)',
-              backdropFilter: 'blur(10px)',
-              WebkitBackdropFilter: 'blur(10px)',
-              border: '1px solid rgba(255,107,53,0.3)',
-              borderRadius: 20,
-              padding: '4px 14px',
-              fontSize: '0.7rem',
-              fontWeight: 800,
-              color: '#e85d00',
-              whiteSpace: 'nowrap',
-              letterSpacing: '0.04em',
-            }}
-          >
-            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
-              🔥
-            </span>
-            <span>ぬいバナナ</span>
-            <span
-              style={{
-                opacity: 0.65,
-                fontWeight: 600,
-                fontVariantNumeric: 'tabular-nums',
-              }}
-            >
-              {feverRemaining}s
-            </span>
-          </div>
-        </>
-      )}
-
-      {/* allGiant：上部カウントダウンバー + 中央ラベル */}
-      {isAllGiant && (
-        <>
-          <div
-            style={{
-              position: 'fixed',
-              top: isFever ? 5 : 0,
-              left: 0,
-              right: 0,
-              height: 5,
-              zIndex: 200,
-              background: 'rgba(0,0,0,0.06)',
-              pointerEvents: 'none',
-            }}
-          >
-            <div
-              style={{
-                height: '100%',
-                width: `${allGiantPercent}%`,
-                background: 'linear-gradient(90deg, #a855f7, #ec4899, #a855f7)',
-                backgroundSize: '200% 100%',
-                boxShadow:
-                  '0 0 12px rgba(168,85,247,0.8), 0 0 4px rgba(236,72,153,0.6)',
-                borderRadius: '0 3px 3px 0',
-                transition: 'width 0.5s linear',
-                animation: 'feverBarShimmer 2s linear infinite',
-              }}
-            />
-          </div>
-          <div
-            className="effect-status-label"
-            role="status"
-            aria-label={`マジックバナナ 残り${allGiantRemaining}秒`}
-            style={{
-              position: 'fixed',
-              top: isFever ? 36 : 10,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              zIndex: 201,
-              pointerEvents: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              background: 'rgba(168, 85, 247, 0.12)',
-              backdropFilter: 'blur(10px)',
-              WebkitBackdropFilter: 'blur(10px)',
-              border: '1px solid rgba(168,85,247,0.3)',
-              borderRadius: 20,
-              padding: '4px 14px',
-              fontSize: '0.7rem',
-              fontWeight: 800,
-              color: 'var(--special-magic)',
-              whiteSpace: 'nowrap',
-              letterSpacing: '0.04em',
-            }}
-          >
-            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
-              ✨
-            </span>
-            <span>マジックバナナ</span>
-            <span
-              style={{
-                opacity: 0.65,
-                fontWeight: 600,
-                fontVariantNumeric: 'tabular-nums',
-              }}
-            >
-              {allGiantRemaining}s
-            </span>
-          </div>
-        </>
-      )}
-
-      {/* oneKind：上部カウントダウンバー + 中央ラベル */}
-      {isOneKind && (
-        <>
-          <div
-            style={{
-              position: 'fixed',
-              top: [isFever, isAllGiant].filter(Boolean).length * 5,
-              left: 0,
-              right: 0,
-              height: 5,
-              zIndex: 200,
-              background: 'rgba(0,0,0,0.06)',
-              pointerEvents: 'none',
-            }}
-          >
-            <div
-              style={{
-                height: '100%',
-                width: `${oneKindPercent}%`,
-                background: 'linear-gradient(90deg, #06b6d4, #3b82f6, #06b6d4)',
-                backgroundSize: '200% 100%',
-                boxShadow:
-                  '0 0 12px rgba(6,182,212,0.8), 0 0 4px rgba(59,130,246,0.6)',
-                borderRadius: '0 3px 3px 0',
-                transition: 'width 0.5s linear',
-                animation: 'feverBarShimmer 2s linear infinite',
-              }}
-            />
-          </div>
-          <div
-            className="effect-status-label"
-            role="status"
-            aria-label={`oneバナナ 残り${oneKindRemaining}秒`}
-            style={{
-              position: 'fixed',
-              top: 10 + [isFever, isAllGiant].filter(Boolean).length * 26,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              zIndex: 201,
-              pointerEvents: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              background: 'rgba(6, 182, 212, 0.12)',
-              backdropFilter: 'blur(10px)',
-              WebkitBackdropFilter: 'blur(10px)',
-              border: '1px solid rgba(6,182,212,0.3)',
-              borderRadius: 20,
-              padding: '4px 14px',
-              fontSize: '0.7rem',
-              fontWeight: 800,
-              color: '#0891b2',
-              whiteSpace: 'nowrap',
-              letterSpacing: '0.04em',
-            }}
-          >
-            <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
-              🍌
-            </span>
-            <span>oneバナナ</span>
-            <span
-              style={{
-                opacity: 0.65,
-                fontWeight: 600,
-                fontVariantNumeric: 'tabular-nums',
-              }}
-            >
-              {oneKindRemaining}s
-            </span>
-          </div>
-        </>
-      )}
+      <ActiveEffectStatusBars
+        isFever={isFever}
+        feverEndTime={feverEndTime}
+        feverDuration={feverDuration}
+        isAllGiant={isAllGiant}
+        allGiantEndTime={allGiantEndTime}
+        allGiantDuration={allGiantDuration}
+        isOneKind={isOneKind}
+        oneKindEndTime={oneKindEndTime}
+        oneKindDuration={oneKindDuration}
+      />
 
       <BananaTree
         score={score}
@@ -855,45 +354,8 @@ function App() {
         waterBoostPercent={Math.round((0.2 + treeWaterBonus) * 100)}
         waterCostDiscount={treeWaterCostDiscount}
       />
-      {floatingCoins.map((coin) => (
-        <div
-          key={coin.id}
-          style={{
-            position: 'fixed',
-            left: coin.x,
-            bottom: 120,
-            transform: 'translateX(-50%)',
-            zIndex: 20,
-            fontSize: '1.6rem',
-            fontWeight: 900,
-            fontFamily: '"Outfit", sans-serif',
-            color: 'var(--accent-gold)',
-            pointerEvents: 'none',
-            animation:
-              'floatUpFade 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards',
-            willChange: 'transform, opacity',
-            contain: 'layout style',
-            textShadow:
-              '0 2px 10px rgba(255,215,0,0.6), 0 0 20px rgba(255,215,0,0.3)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            whiteSpace: 'nowrap',
-          }}
-        >
-          <img
-            src={`${import.meta.env.BASE_URL}coin.png`}
-            alt="coin"
-            style={{
-              width: 28,
-              height: 28,
-              objectFit: 'contain',
-              filter: 'drop-shadow(0 2px 6px rgba(212,175,55,0.6))',
-            }}
-          />
-          <span>+1</span>
-        </div>
-      ))}
+
+      <FloatingCoinList coins={floatingCoins} />
       {floatingTexts.map((text) => (
         <FloatingScoreText
           key={text.id}
@@ -901,19 +363,15 @@ function App() {
           color={scoreColor(text.tier)}
         />
       ))}
-
       {clickEffects.map((effect) => (
         <ClickRipple key={effect.id} effect={effect} />
       ))}
-
       {feverBursts.map((burst) => (
         <FeverBurst key={burst.id} burst={burst} />
       ))}
-
       {spawnFlashes.map((flash) => (
         <SpawnFlash key={flash.id} flash={flash} />
       ))}
-
       {coinFlashes.map((flash) => (
         <CoinSpawnFlash key={flash.id} flash={flash} />
       ))}
@@ -943,7 +401,7 @@ function App() {
         onAdjustCoins={adjustCoins}
         isOneKind={isOneKind}
         oneKindSelection={oneKindSelection}
-        onSpecialSpawn={handleSpecialSpawn}
+        onSpecialSpawn={triggerSpawnFlash}
         treeMutationRateBonus={treeMutationRateBonus}
         treeCriticalClickChance={treeCriticalClickChance}
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,10 +114,15 @@ function App() {
 
   const bananaWorldRef = useRef(null);
 
+  const spawnPhysicsCoin = useCallback(
+    (x) => bananaWorldRef.current?.spawnCoin(x),
+    [],
+  );
+
   const { primeTreeLevel } = useTreeLevelUpCoins({
     treeLevel,
     coinsPerLevelUp,
-    spawnPhysicsCoin: (x) => bananaWorldRef.current?.spawnCoin(x),
+    spawnPhysicsCoin,
     spawnCoinFlashes,
   });
 

--- a/src/components/auth/AuthToolbar.jsx
+++ b/src/components/auth/AuthToolbar.jsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import ProfileModal from './ProfileModal';
+import LeaderboardModal from '../ui/LeaderboardModal';
+
+function AuthToolbar({
+  authEnabled,
+  user,
+  userName,
+  onUserNameChange,
+  signOut,
+}) {
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
+
+  if (!authEnabled) return null;
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          top: 12,
+          right: 12,
+          zIndex: 50,
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'flex-end',
+          gap: 6,
+          maxWidth: 'calc(100vw - 24px)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="logout-button"
+          onClick={() => setIsLeaderboardOpen(true)}
+          aria-label="リーダーボード"
+          title="リーダーボード"
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+            <polyline points="17 6 23 6 23 12" />
+          </svg>
+          <span>Ranking</span>
+        </button>
+        <button
+          className="logout-button"
+          onClick={() => setIsProfileOpen(true)}
+          aria-label="プロフィール設定"
+          title={userName ?? ''}
+          style={{ gap: 5 }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="8" r="4" />
+            <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+          </svg>
+          <span
+            style={{
+              maxWidth: 80,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {userName ?? '…'}
+          </span>
+        </button>
+        <button
+          className="logout-button"
+          onClick={signOut}
+          aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
+          title={user?.email}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+          <span>Logout</span>
+        </button>
+      </div>
+      {isProfileOpen && (
+        <ProfileModal
+          userName={userName}
+          onClose={() => setIsProfileOpen(false)}
+          onSaved={(newName) => onUserNameChange(newName)}
+        />
+      )}
+      {isLeaderboardOpen && (
+        <LeaderboardModal
+          currentUserName={userName}
+          onClose={() => setIsLeaderboardOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+export default AuthToolbar;

--- a/src/components/ui/ActiveEffectStatusBars.jsx
+++ b/src/components/ui/ActiveEffectStatusBars.jsx
@@ -1,0 +1,163 @@
+const BAR_HEIGHT = 5;
+const LABEL_STACK_OFFSET = 26;
+
+function EffectStatusBar({ effect, index }) {
+  const {
+    percent,
+    remaining,
+    name,
+    ariaLabel,
+    icon,
+    barGradient,
+    barShadow,
+    labelBg,
+    labelBorder,
+    labelColor,
+  } = effect;
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          top: index * BAR_HEIGHT,
+          left: 0,
+          right: 0,
+          height: BAR_HEIGHT,
+          zIndex: 200,
+          background: 'rgba(0,0,0,0.06)',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          style={{
+            height: '100%',
+            width: `${percent}%`,
+            background: barGradient,
+            backgroundSize: '200% 100%',
+            boxShadow: barShadow,
+            borderRadius: '0 3px 3px 0',
+            transition: 'width 0.5s linear',
+            animation: 'feverBarShimmer 2s linear infinite',
+          }}
+        />
+      </div>
+      <div
+        className="effect-status-label"
+        role="status"
+        aria-label={ariaLabel}
+        style={{
+          position: 'fixed',
+          top: 10 + index * LABEL_STACK_OFFSET,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 201,
+          pointerEvents: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          background: labelBg,
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+          border: labelBorder,
+          borderRadius: 20,
+          padding: '4px 14px',
+          fontSize: '0.7rem',
+          fontWeight: 800,
+          color: labelColor,
+          whiteSpace: 'nowrap',
+          letterSpacing: '0.04em',
+        }}
+      >
+        <span style={{ fontSize: '0.85rem' }} aria-hidden="true">
+          {icon}
+        </span>
+        <span>{name}</span>
+        <span
+          style={{
+            opacity: 0.65,
+            fontWeight: 600,
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
+          {remaining}s
+        </span>
+      </div>
+    </>
+  );
+}
+
+const remainingSeconds = (endTime) =>
+  Math.max(0, Math.ceil((endTime - Date.now()) / 1000));
+
+const remainingPercent = (endTime, duration) =>
+  duration > 0
+    ? Math.max(
+        0,
+        Math.min(100, ((endTime - Date.now()) / (duration * 1000)) * 100),
+      )
+    : 0;
+
+function ActiveEffectStatusBars({
+  isFever,
+  feverEndTime,
+  feverDuration,
+  isAllGiant,
+  allGiantEndTime,
+  allGiantDuration,
+  isOneKind,
+  oneKindEndTime,
+  oneKindDuration,
+}) {
+  const feverRemaining = remainingSeconds(feverEndTime);
+  const allGiantRemaining = remainingSeconds(allGiantEndTime);
+  const oneKindRemaining = remainingSeconds(oneKindEndTime);
+
+  const effects = [
+    isFever && {
+      key: 'fever',
+      name: 'ぬいバナナ',
+      ariaLabel: `ぬいバナナフィーバー 残り${feverRemaining}秒`,
+      icon: '🔥',
+      remaining: feverRemaining,
+      percent: remainingPercent(feverEndTime, feverDuration),
+      barGradient: 'linear-gradient(90deg, #ff6b35, #ffd700, #ff9f00)',
+      barShadow: '0 0 12px rgba(255,107,53,0.8), 0 0 4px rgba(255,215,0,0.6)',
+      labelBg: 'rgba(255, 100, 30, 0.12)',
+      labelBorder: '1px solid rgba(255,107,53,0.3)',
+      labelColor: '#e85d00',
+    },
+    isAllGiant && {
+      key: 'allGiant',
+      name: 'マジックバナナ',
+      ariaLabel: `マジックバナナ 残り${allGiantRemaining}秒`,
+      icon: '✨',
+      remaining: allGiantRemaining,
+      percent: remainingPercent(allGiantEndTime, allGiantDuration),
+      barGradient: 'linear-gradient(90deg, #a855f7, #ec4899, #a855f7)',
+      barShadow: '0 0 12px rgba(168,85,247,0.8), 0 0 4px rgba(236,72,153,0.6)',
+      labelBg: 'rgba(168, 85, 247, 0.12)',
+      labelBorder: '1px solid rgba(168,85,247,0.3)',
+      labelColor: 'var(--special-magic)',
+    },
+    isOneKind && {
+      key: 'oneKind',
+      name: 'oneバナナ',
+      ariaLabel: `oneバナナ 残り${oneKindRemaining}秒`,
+      icon: '🍌',
+      remaining: oneKindRemaining,
+      percent: remainingPercent(oneKindEndTime, oneKindDuration),
+      barGradient: 'linear-gradient(90deg, #06b6d4, #3b82f6, #06b6d4)',
+      barShadow: '0 0 12px rgba(6,182,212,0.8), 0 0 4px rgba(59,130,246,0.6)',
+      labelBg: 'rgba(6, 182, 212, 0.12)',
+      labelBorder: '1px solid rgba(6,182,212,0.3)',
+      labelColor: '#0891b2',
+    },
+  ].filter(Boolean);
+
+  return effects.map((effect, index) => (
+    <EffectStatusBar key={effect.key} effect={effect} index={index} />
+  ));
+}
+
+export default ActiveEffectStatusBars;

--- a/src/components/ui/FloatingCoinList.jsx
+++ b/src/components/ui/FloatingCoinList.jsx
@@ -1,0 +1,42 @@
+function FloatingCoinList({ coins }) {
+  return coins.map((coin) => (
+    <div
+      key={coin.id}
+      style={{
+        position: 'fixed',
+        left: coin.x,
+        bottom: 120,
+        transform: 'translateX(-50%)',
+        zIndex: 20,
+        fontSize: '1.6rem',
+        fontWeight: 900,
+        fontFamily: '"Outfit", sans-serif',
+        color: 'var(--accent-gold)',
+        pointerEvents: 'none',
+        animation: 'floatUpFade 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards',
+        willChange: 'transform, opacity',
+        contain: 'layout style',
+        textShadow:
+          '0 2px 10px rgba(255,215,0,0.6), 0 0 20px rgba(255,215,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <img
+        src={`${import.meta.env.BASE_URL}coin.png`}
+        alt="coin"
+        style={{
+          width: 28,
+          height: 28,
+          objectFit: 'contain',
+          filter: 'drop-shadow(0 2px 6px rgba(212,175,55,0.6))',
+        }}
+      />
+      <span>+1</span>
+    </div>
+  ));
+}
+
+export default FloatingCoinList;

--- a/src/hooks/useDevMode.js
+++ b/src/hooks/useDevMode.js
@@ -6,7 +6,8 @@ export default function useDevMode() {
 
   useEffect(() => {
     const handleKeyDown = (e) => {
-      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+      // CapsLock オン時は e.key が 'd' になるため e.code も併用する
+      if (e.ctrlKey && e.shiftKey && (e.code === 'KeyD' || e.key === 'D')) {
         e.preventDefault();
         setDevMode((prev) => !prev);
       }

--- a/src/hooks/useDevMode.js
+++ b/src/hooks/useDevMode.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+// Ctrl+Shift+D で開発者モードを切り替える
+export default function useDevMode() {
+  const [devMode, setDevMode] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+        e.preventDefault();
+        setDevMode((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return devMode;
+}

--- a/src/hooks/useScoreTracking.js
+++ b/src/hooks/useScoreTracking.js
@@ -1,0 +1,108 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const MAX_FLOATING_TEXTS = 15;
+const MERGE_DISTANCE_PX = 60;
+const MAX_MERGED_TEXTS_PER_FRAME = 8;
+const SCORE_HISTORY_WINDOW_MS = 5000;
+const PER_SECOND_INTERVAL_MS = 500;
+const SCORE_BUMP_DURATION_MS = 300;
+const FLOATING_TEXT_DURATION_MS = 1200;
+
+let _textId = 0;
+
+export default function useScoreTracking() {
+  const [score, setScore] = useState(0);
+  const [scoreBump, setScoreBump] = useState(false);
+  const [perSecond, setPerSecond] = useState(0);
+  const [floatingTexts, setFloatingTexts] = useState([]);
+
+  // 実測ローリング平均（直近 5 秒の実スコア履歴から算出）
+  const scoreHistoryRef = useRef([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      const cutoff = Date.now() - SCORE_HISTORY_WINDOW_MS;
+      scoreHistoryRef.current = scoreHistoryRef.current.filter(
+        (e) => e.time > cutoff,
+      );
+      const total = scoreHistoryRef.current.reduce((s, e) => s + e.score, 0);
+      setPerSecond(Math.round(total / (SCORE_HISTORY_WINDOW_MS / 1000)));
+    }, PER_SECOND_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // スコアテキストをフレーム単位でバッチ集約し、DOM 要素数を削減
+  const scoreBatchRef = useRef([]);
+  const scoreRafRef = useRef(0);
+
+  const handleScore = useCallback((scoreItems) => {
+    const total = scoreItems.reduce((sum, item) => sum + item.score, 0);
+    setScore((s) => s + total);
+    scoreHistoryRef.current.push({ time: Date.now(), score: total });
+    setScoreBump(true);
+    setTimeout(() => setScoreBump(false), SCORE_BUMP_DURATION_MS);
+
+    scoreBatchRef.current.push(...scoreItems);
+    if (scoreRafRef.current) return;
+
+    scoreRafRef.current = requestAnimationFrame(() => {
+      scoreRafRef.current = 0;
+      const batch = scoreBatchRef.current;
+      scoreBatchRef.current = [];
+      if (batch.length === 0) return;
+
+      // 同フレーム内のスコアを X 位置で近いもの同士にまとめる
+      const merged = [];
+      const sorted = batch.sort((a, b) => a.x - b.x);
+      let current = { ...sorted[0] };
+      for (let i = 1; i < sorted.length; i++) {
+        const item = sorted[i];
+        if (
+          Math.abs(item.x - current.x) < MERGE_DISTANCE_PX &&
+          item.tier === current.tier
+        ) {
+          current.score += item.score;
+        } else {
+          merged.push(current);
+          current = { ...item };
+        }
+      }
+      merged.push(current);
+      const limited =
+        merged.length > MAX_MERGED_TEXTS_PER_FRAME
+          ? merged.slice(0, MAX_MERGED_TEXTS_PER_FRAME)
+          : merged;
+
+      const newTexts = limited.map((item) => ({
+        id: ++_textId,
+        value: item.score,
+        tier: item.tier,
+        x: Math.max(40, Math.min(window.innerWidth - 40, item.x)),
+      }));
+
+      setFloatingTexts((prev) => {
+        const combined = [...prev, ...newTexts];
+        return combined.length > MAX_FLOATING_TEXTS
+          ? combined.slice(combined.length - MAX_FLOATING_TEXTS)
+          : combined;
+      });
+      setTimeout(() => {
+        const ids = new Set(newTexts.map((t) => t.id));
+        setFloatingTexts((prev) => prev.filter((t) => !ids.has(t.id)));
+      }, FLOATING_TEXT_DURATION_MS);
+    });
+  }, []);
+
+  const adjustScore = useCallback((delta) => {
+    setScore((s) => Math.max(0, s + delta));
+  }, []);
+
+  return {
+    score,
+    setScore,
+    scoreBump,
+    perSecond,
+    floatingTexts,
+    handleScore,
+    adjustScore,
+  };
+}

--- a/src/hooks/useTreeLevelUpCoins.js
+++ b/src/hooks/useTreeLevelUpCoins.js
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useCallback } from 'react';
+import useLatestRef from './useLatestRef';
+
+// ツリーレベルアップ検知で物理コインスポーン + フラッシュエフェクトを発火する
+export default function useTreeLevelUpCoins({
+  treeLevel,
+  coinsPerLevelUp,
+  spawnPhysicsCoin,
+  spawnCoinFlashes,
+}) {
+  const prevTreeLevelRef = useRef(null);
+  const coinsPerLevelUpRef = useLatestRef(coinsPerLevelUp);
+  const spawnPhysicsCoinRef = useLatestRef(spawnPhysicsCoin);
+  const spawnCoinFlashesRef = useLatestRef(spawnCoinFlashes);
+
+  useEffect(() => {
+    if (prevTreeLevelRef.current === null) {
+      prevTreeLevelRef.current = treeLevel;
+      return;
+    }
+    if (treeLevel > prevTreeLevelRef.current) {
+      const count = coinsPerLevelUpRef.current;
+      const xs = [];
+      for (let i = 0; i < count; i++) {
+        const x = 80 + Math.random() * (window.innerWidth - 160);
+        spawnPhysicsCoinRef.current?.(x);
+        xs.push(x);
+      }
+      spawnCoinFlashesRef.current?.(xs);
+    }
+    prevTreeLevelRef.current = treeLevel;
+    // ref 経由で最新値を参照するため deps には含めない
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [treeLevel]);
+
+  // セーブ復元時にレベルアップ誤検知を防ぐため、事前に prev を合わせる
+  const primeTreeLevel = useCallback((level) => {
+    prevTreeLevelRef.current = level;
+  }, []);
+
+  return { primeTreeLevel };
+}

--- a/src/hooks/useVisualEffects.js
+++ b/src/hooks/useVisualEffects.js
@@ -1,0 +1,94 @@
+import { useState, useCallback } from 'react';
+
+const MAX_CLICK_EFFECTS = 5;
+const MAX_SPAWN_FLASHES = 3;
+const MAX_FEVER_BURSTS = 3;
+
+const CLICK_RIPPLE_DURATION_MS = 600;
+const FEVER_BURST_DURATION_MS = 1100;
+const SPAWN_FLASH_DURATION_MS = 1200;
+const COIN_FLASH_DURATION_MS = 1800;
+const FLOATING_COIN_DURATION_MS = 1200;
+
+let _effectId = 0;
+
+const capTail = (list, max) =>
+  list.length > max ? list.slice(list.length - max) : list;
+
+export default function useVisualEffects() {
+  const [clickEffects, setClickEffects] = useState([]);
+  const [feverBursts, setFeverBursts] = useState([]);
+  const [spawnFlashes, setSpawnFlashes] = useState([]);
+  const [coinFlashes, setCoinFlashes] = useState([]);
+  const [floatingCoins, setFloatingCoins] = useState([]);
+
+  const triggerClickRipple = useCallback((clientX, clientY) => {
+    const id = ++_effectId;
+    setClickEffects((prev) =>
+      capTail([...prev, { id, x: clientX, y: clientY }], MAX_CLICK_EFFECTS),
+    );
+    setTimeout(
+      () => setClickEffects((prev) => prev.filter((ef) => ef.id !== id)),
+      CLICK_RIPPLE_DURATION_MS,
+    );
+  }, []);
+
+  const triggerSpawnFlash = useCallback((x, itemId) => {
+    const id = ++_effectId;
+    setSpawnFlashes((prev) =>
+      capTail([...prev, { id, x, itemId }], MAX_SPAWN_FLASHES),
+    );
+    setTimeout(
+      () => setSpawnFlashes((prev) => prev.filter((f) => f.id !== id)),
+      SPAWN_FLASH_DURATION_MS,
+    );
+  }, []);
+
+  const triggerFeverBurst = useCallback((x, y, itemId) => {
+    const id = ++_effectId;
+    setFeverBursts((prev) =>
+      capTail([...prev, { id, x, y, itemId }], MAX_FEVER_BURSTS),
+    );
+    setTimeout(
+      () => setFeverBursts((prev) => prev.filter((b) => b.id !== id)),
+      FEVER_BURST_DURATION_MS,
+    );
+  }, []);
+
+  const spawnCoinFlashes = useCallback((xs) => {
+    if (!xs.length) return;
+    const entries = xs.map((x) => ({ id: ++_effectId, x }));
+    setCoinFlashes((prev) => [...prev, ...entries]);
+    const idSet = new Set(entries.map((e) => e.id));
+    setTimeout(
+      () => setCoinFlashes((prev) => prev.filter((f) => !idSet.has(f.id))),
+      COIN_FLASH_DURATION_MS,
+    );
+  }, []);
+
+  const spawnFloatingCoin = useCallback((x) => {
+    const id = ++_effectId;
+    const clampedX = Math.max(
+      60,
+      Math.min(window.innerWidth - 60, x ?? window.innerWidth / 2),
+    );
+    setFloatingCoins((prev) => [...prev, { id, x: clampedX }]);
+    setTimeout(
+      () => setFloatingCoins((prev) => prev.filter((c) => c.id !== id)),
+      FLOATING_COIN_DURATION_MS,
+    );
+  }, []);
+
+  return {
+    clickEffects,
+    feverBursts,
+    spawnFlashes,
+    coinFlashes,
+    floatingCoins,
+    triggerClickRipple,
+    triggerSpawnFlash,
+    triggerFeverBurst,
+    spawnCoinFlashes,
+    spawnFloatingCoin,
+  };
+}

--- a/src/services/treeSkillBonuses.js
+++ b/src/services/treeSkillBonuses.js
@@ -1,0 +1,25 @@
+// ツリースキル（chosenSkills）から各種ボーナスを集計する
+
+const MAX_WATER_COST_DISCOUNT = 0.9;
+
+const sumBy = (skills, key) =>
+  skills.reduce((sum, s) => sum + (s[key] ?? 0), 0);
+
+export function computeTreeSkillBonuses(chosenSkills) {
+  const waterBoost = sumBy(chosenSkills, 'waterBoost');
+  const waterCostDiscount = Math.min(
+    sumBy(chosenSkills, 'waterCostDiscount'),
+    MAX_WATER_COST_DISCOUNT,
+  );
+  const coinsPerLevelUp = 1 + sumBy(chosenSkills, 'coinsPerLevelUp');
+  const mutationRateBonus = sumBy(chosenSkills, 'mutationRateBonus');
+  const criticalClickChance = sumBy(chosenSkills, 'criticalClickChance');
+
+  return {
+    waterBoost,
+    waterCostDiscount,
+    coinsPerLevelUp,
+    mutationRateBonus,
+    criticalClickChance,
+  };
+}


### PR DESCRIPTION
## 概要
954行に肥大化していた App.jsx から、ゲーム状態・UI エフェクト・認証などの関心事をフック／サービス／コンポーネントに切り出し、App.jsx を配線中心の薄いレイヤーに再構成しました。

## 関連イシュー
Closes #106

## 変更内容
- **hooks 抽出**
  - `useDevMode.js` — Ctrl+Shift+D トグル
  - `useScoreTracking.js` — score / scoreBump / perSecond / floatingTexts の RAF バッチ集約
  - `useVisualEffects.js` — clickEffects / feverBursts / spawnFlashes / coinFlashes / floatingCoins
  - `useTreeLevelUpCoins.js` — ツリーレベルアップ時のコインスポーン副作用（復元時の誤検知回避 API `primeTreeLevel` 付き）
- **services 抽出**
  - `treeSkillBonuses.js` — `chosenSkills` からの各種ボーナス集計を純関数化
- **components 抽出**
  - `AuthToolbar.jsx` — Ranking / Profile / Logout ボタンと両モーダル
  - `ActiveEffectStatusBars.jsx` — 3つの上部バー＋中央ラベルをデータ駆動で共通化（約220行の重複を解消）
  - `FloatingCoinList.jsx` — +1 コインの浮遊表示
- **App.jsx**
  - 954行 → 412行。render-time の ref 書き換えを `useLatestRef` に置き換え。

## 備考
- 振る舞いは保つことを最優先にしたため機能変更なし。
- 自動テストは未整備のため、以下の手動確認を推奨:
  - ぬい/マジック/one バナナの単独・重ね掛け時のバー／ラベル位置
  - ツリーレベルアップ時のコイン数（coinsPerLevelUp 反映）
  - セーブ復元直後にレベルアップ誤発火しないこと
  - フィーバー中の floatingTexts マージ・上限
  - クリック波紋・コイン収集 +1・特殊バナナの spawnFlash / feverBurst
  - 認証ツールバー 3 ボタンと両モーダル
- `npm run format` / `lint` / `build` すべて通過済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 認証ツールバーを追加。プロフィール、リーダーボード、ログアウト機能に対応
  * 開発者モード（Ctrl+Shift+D で切り替え可能）を実装
  * アクティブなゲーム効果のステータスバー表示を改善

* **リファクタリング**
  * ゲーム UI とエフェクトロジックを整理。スコア追跡とビジュアルエフェクト管理を最適化
  * コンポーネント構成を再編成し、パフォーマンスを向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->