### PR TITLE
feat: combine profile and logout buttons into a settings menu

### DIFF
--- a/src/components/auth/AuthToolbar.jsx
+++ b/src/components/auth/AuthToolbar.jsx
@@ -90,9 +90,9 @@ function AuthToolbar({
         >
           <button
             className="logout-button"
+            type="button"
             onClick={() => setIsSettingsOpen((prev) => !prev)}
             aria-label="設定"
-            aria-haspopup="menu"
             aria-expanded={isSettingsOpen}
             title={user?.email ?? '設定'}
           >
@@ -113,17 +113,12 @@ function AuthToolbar({
             <span>Settings</span>
           </button>
           {isSettingsOpen && (
-            <div
-              role="menu"
-              aria-label="設定メニュー"
-              className="glass-panel"
-              style={menuStyles.menu}
-            >
+            <div className="glass-panel" style={menuStyles.menu}>
               <button
                 type="button"
-                role="menuitem"
                 className="settings-menu-item"
                 onClick={handleOpenProfile}
+                aria-label="プロフィール設定を開く"
               >
                 <svg
                   width="14"
@@ -148,9 +143,9 @@ function AuthToolbar({
               </button>
               <button
                 type="button"
-                role="menuitem"
                 className="settings-menu-item"
                 onClick={handleSignOut}
+                aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
               >
                 <svg
                   width="14"

--- a/src/components/auth/AuthToolbar.jsx
+++ b/src/components/auth/AuthToolbar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ProfileModal from './ProfileModal';
 import LeaderboardModal from '../ui/LeaderboardModal';
 
@@ -11,8 +11,40 @@ function AuthToolbar({
 }) {
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const settingsRef = useRef(null);
+
+  useEffect(() => {
+    if (!isSettingsOpen) return undefined;
+    const handlePointerDown = (event) => {
+      if (settingsRef.current && !settingsRef.current.contains(event.target)) {
+        setIsSettingsOpen(false);
+      }
+    };
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') setIsSettingsOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isSettingsOpen]);
 
   if (!authEnabled) return null;
+
+  const handleOpenProfile = () => {
+    setIsSettingsOpen(false);
+    setIsProfileOpen(true);
+  };
+
+  const handleSignOut = () => {
+    setIsSettingsOpen(false);
+    signOut();
+  };
 
   return (
     <>
@@ -52,61 +84,99 @@ function AuthToolbar({
           </svg>
           <span>Ranking</span>
         </button>
-        <button
-          className="logout-button"
-          onClick={() => setIsProfileOpen(true)}
-          aria-label="プロフィール設定"
-          title={userName ?? ''}
-          style={{ gap: 5 }}
+        <div
+          ref={settingsRef}
+          style={{ position: 'relative', display: 'inline-flex' }}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
+          <button
+            className="logout-button"
+            onClick={() => setIsSettingsOpen((prev) => !prev)}
+            aria-label="設定"
+            aria-haspopup="menu"
+            aria-expanded={isSettingsOpen}
+            title={user?.email ?? '設定'}
           >
-            <circle cx="12" cy="8" r="4" />
-            <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
-          </svg>
-          <span
-            style={{
-              maxWidth: 80,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {userName ?? '…'}
-          </span>
-        </button>
-        <button
-          className="logout-button"
-          onClick={signOut}
-          aria-label={`ログアウト${user?.email ? ` (${user.email})` : ''}`}
-          title={user?.email}
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-            <polyline points="16 17 21 12 16 7" />
-            <line x1="21" y1="12" x2="9" y2="12" />
-          </svg>
-          <span>Logout</span>
-        </button>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            <span>Settings</span>
+          </button>
+          {isSettingsOpen && (
+            <div
+              role="menu"
+              aria-label="設定メニュー"
+              className="glass-panel"
+              style={menuStyles.menu}
+            >
+              <button
+                type="button"
+                role="menuitem"
+                className="settings-menu-item"
+                onClick={handleOpenProfile}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="8" r="4" />
+                  <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+                </svg>
+                <span style={menuStyles.itemLabel}>
+                  <span style={menuStyles.itemTitle}>プロフィール</span>
+                  {userName && (
+                    <span style={menuStyles.itemSubtitle}>{userName}</span>
+                  )}
+                </span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="settings-menu-item"
+                onClick={handleSignOut}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                  <polyline points="16 17 21 12 16 7" />
+                  <line x1="21" y1="12" x2="9" y2="12" />
+                </svg>
+                <span style={menuStyles.itemLabel}>
+                  <span style={menuStyles.itemTitle}>ログアウト</span>
+                  {user?.email && (
+                    <span style={menuStyles.itemSubtitle}>{user.email}</span>
+                  )}
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
       {isProfileOpen && (
         <ProfileModal
@@ -124,5 +194,44 @@ function AuthToolbar({
     </>
   );
 }
+
+const menuStyles = {
+  menu: {
+    position: 'absolute',
+    top: 'calc(100% + 6px)',
+    right: 0,
+    minWidth: 180,
+    padding: 6,
+    borderRadius: 14,
+    background: 'rgba(255,255,255,0.96)',
+    border: '1px solid var(--accent-gold-soft)',
+    boxShadow: '0 12px 32px rgba(0,0,0,0.18)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    zIndex: 60,
+  },
+  itemLabel: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    minWidth: 0,
+    flex: 1,
+  },
+  itemTitle: {
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    color: '#3a3020',
+    letterSpacing: '0.02em',
+  },
+  itemSubtitle: {
+    fontSize: '0.65rem',
+    color: '#8a7a60',
+    maxWidth: 140,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+};
 
 export default AuthToolbar;

--- a/src/index.css
+++ b/src/index.css
@@ -1057,6 +1057,38 @@ body {
   transform: scale(0.96);
 }
 
+/* ── Settings menu ── */
+.settings-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-main);
+  font-family: Outfit, sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    transform 0.18s ease;
+}
+
+.settings-menu-item:hover {
+  background: rgba(212, 175, 55, 0.12);
+}
+
+.settings-menu-item:active {
+  transform: scale(0.98);
+}
+
+.settings-menu-item:focus-visible {
+  outline: 2px solid rgba(212, 175, 55, 0.6);
+  outline-offset: 2px;
+}
+
 /* Custom Scrollbar for premium feel */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary
- プロフィールボタンとログアウトボタンを単一の **Settings** ボタンに統合し、クリックで開くドロップダウンメニューに「プロフィール」「ログアウト」を集約
- メニューはメニュー外クリック・タッチおよび Escape キーで閉じる
- ドロップダウン項目向けに `.settings-menu-item` のホバー／フォーカススタイルを追加

Closes #110

## Test plan
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] 手動確認: 設定ボタン → プロフィール／ログアウトの動作、メニュー外クリック・Esc で閉じることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ツールバーに設定メニューを追加しました。Profile（プロフィール）とログアウトのオプションを含むドロップダウンメニューが表示されます。
  * メニュー外をクリックするか、Escapeキーを押すことでメニューを閉じることができるようになりました。

* **Style**
  * メニューアイテムのホバーやアクティブ状態のスタイリングを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->